### PR TITLE
Backend logging implementation

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { request } from "./common"
+import { eventStream, request } from "./request"
 
 enum HttpMethod {
     Get = "GET",
@@ -60,6 +60,15 @@ export class JamsocketApi {
         return responseBody
     }
 
+    private async makeAuthenticatedStreamRequest(endpoint: string, callback: (line: string) => void): Promise<void> {
+        const url = `${this.apiBase}${endpoint}`;
+        return eventStream(url, {
+            method: HttpMethod.Get,
+            headers: { 'Authorization': `Basic ${this.auth}` }
+        },
+            callback);
+    }
+
     public checkAuth(): Promise<any> {
         const url = `/api/auth`;
         return this.makeAuthenticatedRequest(url, HttpMethod.Get);
@@ -85,5 +94,10 @@ export class JamsocketApi {
     public spawn(username: string, serviceName: string, body: SpawnRequestBody): Promise<SpawnResult> {
         const url = `/api/user/${username}/service/${serviceName}/spawn`
         return this.makeAuthenticatedRequest(url, HttpMethod.Post, body);
+    }
+
+    public streamLogs(backend: string, callback: (line: string) => void): Promise<void> {
+        const url = `/api/backend/${backend}/logs`;
+        return this.makeAuthenticatedStreamRequest(url, callback);
     }
 }

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,0 +1,30 @@
+import { Command } from '@oclif/core'
+import { readJamsocketConfig } from '../common'
+import { JamsocketApi } from '../api'
+
+export default class Logs extends Command {
+    static description = 'Stream logs from a running backend.'
+
+    static examples = [
+        '<%= config.bin %> <%= command.id %> f7em2',
+    ]
+
+    static args = [
+        { name: 'backend', description: 'The name of the backend, a random string of letters and numbers returned by the spawn command.', required: true },
+    ]
+
+    public async run(): Promise<void> {
+        const config = readJamsocketConfig()
+        if (config === null) {
+            this.error('No user credentials found. Log in with jamsocket login')
+        }
+
+        const { args } = await this.parse(Logs)
+        const { auth } = config
+        const api = new JamsocketApi(auth);
+
+        await api.streamLogs(args.backend, (line) => {
+            this.log(line);
+        });
+    }
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,5 @@
 import { homedir, EOL } from 'os'
 import { resolve, dirname } from 'path'
-import * as https from 'https'
 import { existsSync, readFileSync, mkdirSync, writeFileSync, unlinkSync } from 'fs'
 
 export const JAMSOCKET_CONFIG = resolve(homedir(), '.jamsocket', 'config.json')
@@ -38,52 +37,4 @@ export function writeJamsocketConfig(config: JamsocketConfig): void {
 export function deleteJamsocketConfig(): void {
   if (!existsSync(JAMSOCKET_CONFIG)) return
   unlinkSync(JAMSOCKET_CONFIG)
-}
-
-type Header = string | string[] | undefined
-type RequestReturn = {
-  body: string;
-  statusCode: number | undefined;
-  statusMessage: string | undefined;
-  headers: Record<string, Header>;
-}
-export function request(
-  url: string,
-  body: Record<string, unknown> | null,
-  options: Record<string, any>,
-): Promise<RequestReturn> {
-  return new Promise((resolve, reject) => {
-    const wrappedURL = new URL(url)
-    const headers = { ...options.headers }
-    const jsonBody = body && JSON.stringify(body)
-    if (jsonBody !== null) {
-      headers['Content-Length'] = jsonBody.length
-      headers['Content-Type'] = 'application/json'
-    }
-
-    let result = ''
-    const req = https.request({
-      ...options,
-      hostname: wrappedURL.hostname,
-      path: wrappedURL.pathname,
-      headers: headers,
-    }, res => {
-      res.on('data', chunk => {
-        result += chunk
-      })
-      res.on('end', () => {
-        resolve({
-          body: result,
-          statusCode: res.statusCode,
-          statusMessage: res.statusMessage,
-          headers: res.headers,
-        })
-      })
-    })
-    req.on('error', err => {
-      reject(err)
-    })
-    if (jsonBody !== null) req.write(jsonBody)
-    req.end()
-  })
 }

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,94 @@
+import * as https from 'https'
+
+type Header = string | string[] | undefined
+
+type RequestReturn = {
+  body: string;
+  statusCode: number | undefined;
+  statusMessage: string | undefined;
+  headers: Record<string, Header>;
+}
+
+export function request(
+  url: string,
+  body: Record<string, unknown> | null,
+  options: Record<string, any>,
+): Promise<RequestReturn> {
+  return new Promise((resolve, reject) => {
+    const wrappedURL = new URL(url)
+    const headers = { ...options.headers }
+    const jsonBody = body && JSON.stringify(body)
+    if (jsonBody !== null) {
+      headers['Content-Length'] = jsonBody.length
+      headers['Content-Type'] = 'application/json'
+    }
+
+    let result = ''
+    const req = https.request({
+      ...options,
+      hostname: wrappedURL.hostname,
+      path: wrappedURL.pathname,
+      headers: headers,
+    }, res => {
+      res.on('data', chunk => {
+        result += chunk
+      })
+      res.on('end', () => {
+        resolve({
+          body: result,
+          statusCode: res.statusCode,
+          statusMessage: res.statusMessage,
+          headers: res.headers,
+        })
+      })
+    })
+    req.on('error', err => {
+      reject(err)
+    })
+    if (jsonBody !== null) req.write(jsonBody)
+    req.end()
+  })
+}
+
+export function eventStream(
+  url: string,
+  options: Record<string, any>,
+  callback: (line: string) => void,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const wrappedURL = new URL(url)
+    const headers = { ...options.headers }
+    headers['Accept'] = 'text/event-stream';
+
+    const req = https.request({
+      ...options,
+      hostname: wrappedURL.hostname,
+      path: wrappedURL.pathname,
+      headers: headers,
+    }, res => {
+      res.on('data', (chunk: Buffer) => {
+        const lines = chunk.toString().trim().split(/\n\n/);
+        for (let line of lines) {
+          const match = line.match(/data: ?(.+)/);
+          if (match) {
+            callback(match[1])
+          } else {
+            try {
+              const parsed = JSON.parse(line);
+              reject(new Error(parsed.error.message));
+            } catch (e) {
+              reject(new Error(`Expected line to start with data:, got ${line}`));
+            }
+          }
+        }
+      })
+      res.on('end', () => {
+        resolve();
+      })
+    })
+    req.on('error', err => {
+      reject(err)
+    })
+    req.end();
+  })
+}


### PR DESCRIPTION
Adds `jamsocket logs <backend>` command which streams logs.

Known issue: does not attempt to reconnect if the connection times out, which it is currently set to do on the server. The easy fix here might just be to fix that timeout on the server side.