### PR TITLE
save docker config to jamsockets homedir instead of CWD

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -2,7 +2,8 @@ import { homedir, EOL } from 'os'
 import { resolve, dirname } from 'path'
 import { existsSync, readFileSync, mkdirSync, writeFileSync, unlinkSync } from 'fs'
 
-export const JAMSOCKET_CONFIG = resolve(homedir(), '.jamsocket', 'config.json')
+export const JAMSOCKET_CONFIG_DIR = resolve(homedir(), '.jamsocket')
+const JAMSOCKET_CONFIG = resolve(JAMSOCKET_CONFIG_DIR, 'config.json')
 
 export type JamsocketConfig = {
   username: string;


### PR DESCRIPTION
One upside of this is that we've removed dependencies that were only available starting in Node 14. This should make the CLI work for Node 12, too, now.