### PR TITLE
Fix bug in SSE client code

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -71,7 +71,7 @@ export function eventStream(
       res.on('data', (chunk: Buffer) => {
         const lines = chunk.toString().trim().split(/\n\n/)
         for (const line of lines) {
-          const match = line.match(/data: ?(.+)/)
+          const match = line.match(/data: ?(.*)/)
           if (match) {
             callback(match[1])
           } else {


### PR DESCRIPTION
The SSE client did not allow empty lines because the regex expected at least one character.