### PR TITLE
ALLOW_INSECURE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ EXAMPLES
   $ jamsocket login
 ```
 
-_See code: [dist/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.1/dist/commands/login.ts)_
+_See code: [dist/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.2/dist/commands/login.ts)_
 
 ## `jamsocket logout`
 
@@ -81,7 +81,7 @@ EXAMPLES
   $ jamsocket logout
 ```
 
-_See code: [dist/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.1/dist/commands/logout.ts)_
+_See code: [dist/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.2/dist/commands/logout.ts)_
 
 ## `jamsocket logs BACKEND`
 
@@ -101,7 +101,7 @@ EXAMPLES
   $ jamsocket logs f7em2
 ```
 
-_See code: [dist/commands/logs.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.1/dist/commands/logs.ts)_
+_See code: [dist/commands/logs.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.2/dist/commands/logs.ts)_
 
 ## `jamsocket push SERVICE IMAGE`
 
@@ -127,7 +127,7 @@ EXAMPLES
   $ jamsocket push my-service my-image -t my-tag
 ```
 
-_See code: [dist/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.1/dist/commands/push.ts)_
+_See code: [dist/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.2/dist/commands/push.ts)_
 
 ## `jamsocket service create NAME`
 
@@ -186,7 +186,7 @@ EXAMPLES
   $ jamsocket spawn my-service -t latest
 ```
 
-_See code: [dist/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.1/dist/commands/spawn.ts)_
+_See code: [dist/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.2/dist/commands/spawn.ts)_
 
 ## `jamsocket token create SERVICE`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -81,7 +81,19 @@ export class JamsocketApi {
       apiBase = override
     }
 
-    return new JamsocketApi(apiBase, {})
+    const allowInsecure = process.env.ALLOW_INSECURE === 'true'
+    let rejectUnauthorized
+    if (allowInsecure) {
+      if (override === undefined) {
+        console.warn('Insecure connections are only allowed when overriding the Jamsocket server. (Ignoring env var ALLOW_INSECURE)')
+        rejectUnauthorized = true
+      } else {
+        console.warn('Allowing insecure connections. (Found env var ALLOW_INSECURE)')
+        rejectUnauthorized = false
+      }
+    }
+
+    return new JamsocketApi(apiBase, { rejectUnauthorized })
   }
 
   private async makeRequest(endpoint: string, method: HttpMethod, body?: any, headers?: Headers): Promise<any> {

--- a/src/request.ts
+++ b/src/request.ts
@@ -77,7 +77,7 @@ export function eventStream(
       headers: headers,
     }, res => {
       if (res.statusCode !== 200) {
-        reject(new Error("Non-200 status code from API on event stream."))
+        reject(new Error('Non-200 status code from API on event stream.'))
       }
 
       res.on('data', (chunk: Buffer) => {


### PR DESCRIPTION
Adding this env var to ignore cert validation issues when working in dev. This env var is only allowed when setting `JAMSOCKET_SERVER_API` override.