### PR TITLE
v0.2.0 - points to new.jamsocket.dev API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ EXAMPLES
   $ jamsocket login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.4/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0-alpha/src/commands/login.ts)_
 
 ## `jamsocket logout`
 
@@ -81,7 +81,7 @@ EXAMPLES
   $ jamsocket logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.4/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0-alpha/src/commands/logout.ts)_
 
 ## `jamsocket logs BACKEND`
 
@@ -101,7 +101,7 @@ EXAMPLES
   $ jamsocket logs f7em2
 ```
 
-_See code: [src/commands/logs.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.4/src/commands/logs.ts)_
+_See code: [src/commands/logs.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0-alpha/src/commands/logs.ts)_
 
 ## `jamsocket push SERVICE IMAGE`
 
@@ -127,7 +127,7 @@ EXAMPLES
   $ jamsocket push my-service my-image -t my-tag
 ```
 
-_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.4/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0-alpha/src/commands/push.ts)_
 
 ## `jamsocket service create NAME`
 
@@ -186,7 +186,7 @@ EXAMPLES
   $ jamsocket spawn my-service -t latest
 ```
 
-_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.1.4/src/commands/spawn.ts)_
+_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0-alpha/src/commands/spawn.ts)_
 
 ## `jamsocket token create SERVICE`
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ EXAMPLES
   $ jamsocket login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0-alpha/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0/src/commands/login.ts)_
 
 ## `jamsocket logout`
 
@@ -81,7 +81,7 @@ EXAMPLES
   $ jamsocket logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0-alpha/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0/src/commands/logout.ts)_
 
 ## `jamsocket logs BACKEND`
 
@@ -101,7 +101,7 @@ EXAMPLES
   $ jamsocket logs f7em2
 ```
 
-_See code: [src/commands/logs.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0-alpha/src/commands/logs.ts)_
+_See code: [src/commands/logs.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0/src/commands/logs.ts)_
 
 ## `jamsocket push SERVICE IMAGE`
 
@@ -127,7 +127,7 @@ EXAMPLES
   $ jamsocket push my-service my-image -t my-tag
 ```
 
-_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0-alpha/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0/src/commands/push.ts)_
 
 ## `jamsocket service create NAME`
 
@@ -186,7 +186,7 @@ EXAMPLES
   $ jamsocket spawn my-service -t latest
 ```
 
-_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0-alpha/src/commands/spawn.ts)_
+_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.2.0/src/commands/spawn.ts)_
 
 ## `jamsocket token create SERVICE`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.1.4",
+  "version": "0.2.0-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.1.4",
+      "version": "0.2.0-alpha",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.2.0-alpha",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.2.0-alpha",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.2.0-alpha",
+  "version": "0.2.0",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.1.4",
+  "version": "0.2.0-alpha",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -74,7 +74,8 @@ export class JamsocketApi {
     const override = process.env.JAMSOCKET_SERVER_API
     let apiBase
     if (override === undefined) {
-      apiBase = 'https://jamsocket.dev'
+      // Will switch back to https://jamsocket.dev once we complete the migration to Jamsocket's version p2
+      apiBase = 'https://new.jamsocket.dev'
     } else {
       console.warn(`Using Jamsocket server override: ${override}`)
       apiBase = override


### PR DESCRIPTION
This update points the CLI at `new.jamsocket.dev` - the API endpoint of Jamsocket v2. We'll use this while we migrate customers to v2, after which we'll shut down the v1 and point jamsocket.dev's DNS to v2. ~After that we can simply close this PR.~

Update: we've decided to go ahead and publish this now since we have customers onboarding to p2.