### PR TITLE
update jamsocket login command to use api tokens

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -14,7 +14,7 @@ export type SpawnRequestBody = {
   tag?: string;
 }
 
-export type TokenRequestBody = {
+export type SpawnTokenRequestBody = {
   grace_period_seconds?: number;
   port?: number;
   tag?: string;
@@ -40,11 +40,11 @@ export interface SpawnResult {
   status_url?: string,
 }
 
-export interface TokenCreateResult {
+export interface SpawnTokenCreateResult {
   token: string,
 }
 
-export interface TokenRevokeResult {
+export interface SpawnTokenRevokeResult {
   status: string,
 }
 
@@ -198,17 +198,17 @@ export class JamsocketApi {
     return this.makeAuthenticatedRequest(url, HttpMethod.Get, auth)
   }
 
-  public async tokenCreate(username: string, serviceName: string, auth: string, body: TokenRequestBody): Promise<TokenCreateResult> {
+  public async spawnTokenCreate(username: string, serviceName: string, auth: string, body: SpawnTokenRequestBody): Promise<SpawnTokenCreateResult> {
     const url = `/api/user/${username}/service/${serviceName}/token`
     return this.makeAuthenticatedRequest(url, HttpMethod.Post, auth, body)
   }
 
-  public async tokenRevoke(token: string, auth: string): Promise<TokenRevokeResult> {
+  public async spawnTokenRevoke(token: string, auth: string): Promise<SpawnTokenRevokeResult> {
     const url = `/api/token/${token}`
     return this.makeAuthenticatedRequest(url, HttpMethod.Delete, auth)
   }
 
-  public async tokenSpawn(token: string): Promise<SpawnResult> {
+  public async spawnTokenSpawn(token: string): Promise<SpawnResult> {
     const url = `/api/token/${token}/spawn`
     return this.makeRequest(url, HttpMethod.Post, {})
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -96,6 +96,11 @@ export class JamsocketApi {
     return new JamsocketApi(apiBase, { rejectUnauthorized })
   }
 
+  public getLoginUrl(): string {
+    const hostname = new URL(this.apiBase).hostname
+    return `https://app.${hostname}/cli-login`
+  }
+
   private async makeRequest(endpoint: string, method: HttpMethod, body?: any, headers?: Headers): Promise<any> {
     const url = `${this.apiBase}${endpoint}`
     const response = await request(url, body || null, { ...this.options, method, headers })

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -18,10 +18,10 @@ export default class Login extends Command {
     const api = JamsocketApi.fromEnvironment()
     const config = readJamsocketConfig()
     if (config !== null) {
-      const { auth } = config
+      const { username, auth } = config
       try {
         await api.checkAuth(auth)
-        this.log('You are already logged in. To log in with a different token, run jamsocket logout first.')
+        this.log(`You are already logged in with the API token "${username}.********". To log in with a different token, run jamsocket logout first.`)
         return
       } catch (error) {
         const isAuthError = error instanceof AuthenticationError

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -3,15 +3,16 @@ import { JamsocketApi, AuthenticationError } from '../api'
 import { readJamsocketConfig, writeJamsocketConfig } from '../jamsocket-config'
 
 export default class Login extends Command {
-  static description = 'Authenticates user with jamcr.io container registery'
+  static description = 'Authenticates user to the Jamsocket API with a token.'
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> W3guqHFk0FJdtquC.iDxcHZr4rg1AIWPxpnk0SWHm95Vfdl',
   ]
 
-  static flags = {}
-
-  static args = []
+  static args = [
+    { name: 'token', description: 'optional token to log into the CLI with' },
+  ]
 
   public async run(): Promise<void> {
     const api = JamsocketApi.fromEnvironment()
@@ -20,7 +21,7 @@ export default class Login extends Command {
       const { auth } = config
       try {
         await api.checkAuth(auth)
-        this.log(`User ${config.username} is already logged in. To log in with a different user, run jamsocket logout first.`)
+        this.log('You are already logged in. To log in with a different token, run jamsocket logout first.')
         return
       } catch (error) {
         const isAuthError = error instanceof AuthenticationError
@@ -28,15 +29,32 @@ export default class Login extends Command {
       }
     }
 
-    const username = await CliUx.ux.prompt('username')
-    const password = await CliUx.ux.prompt('password', { type: 'hide' })
+    const { args } = await this.parse(Login)
 
-    const buff = Buffer.from(`${username}:${password}`, 'utf-8')
+    let token = args.token.trim()
+    if (!token) {
+      this.log('Generate an API token at the following URL and paste it into the prompt below:\n')
+      this.log(`    ${api.getLoginUrl()}\n`)
+      token = (await CliUx.ux.prompt('token')).trim()
+    }
+
+    if (!token) {
+      throw new Error('Token required to login.')
+    }
+
+    if (!token.includes('.')) {
+      throw new Error('Invalid token. Token must contain a period.')
+    }
+
+    const [publicPortion, privatePortion] = token.split('.')
+
+    const buff = Buffer.from(`${publicPortion}:${privatePortion}`, 'utf-8')
     const auth = buff.toString('base64')
 
     await api.checkAuth(auth)
 
-    writeJamsocketConfig({ username: username, auth: auth })
+    // should tokens be stored like this? or should they explicitly be tokens - no username?
+    writeJamsocketConfig({ username: publicPortion, auth: auth })
     this.log('Login Succeeded')
   }
 }

--- a/src/commands/spawn-token/create.ts
+++ b/src/commands/spawn-token/create.ts
@@ -28,7 +28,7 @@ export default class Create extends Command {
 
     const jamsocket = Jamsocket.fromEnvironment()
 
-    const { token } = await jamsocket.tokenCreate(args.service, flags.grace, flags.port, flags.tag)
+    const { token } = await jamsocket.spawnTokenCreate(args.service, flags.grace, flags.port, flags.tag)
     this.log(token)
   }
 }

--- a/src/commands/spawn-token/revoke.ts
+++ b/src/commands/spawn-token/revoke.ts
@@ -2,7 +2,7 @@ import { Command } from '@oclif/core'
 import { Jamsocket } from '../../jamsocket'
 
 export default class Create extends Command {
-  static description = 'Revoke a token permanently.'
+  static description = 'Revoke a spawn token permanently.'
 
   static examples = [
     '<%= config.bin %> <%= command.id %> jNCuGvecEEk706SDm2xYRJc7mqplE2',
@@ -14,7 +14,7 @@ export default class Create extends Command {
     const { args } = await this.parse(Create)
     const jamsocket = Jamsocket.fromEnvironment()
 
-    await jamsocket.tokenRevoke(args.token)
-    this.log(`Revoked token: ${args.token}`)
+    await jamsocket.spawnTokenRevoke(args.token)
+    this.log(`Revoked spawn token: ${args.token}`)
   }
 }

--- a/src/commands/spawn-token/spawn.ts
+++ b/src/commands/spawn-token/spawn.ts
@@ -2,7 +2,7 @@ import { Command } from '@oclif/core'
 import { JamsocketApi } from '../../api'
 
 export default class Spawn extends Command {
-  static description = 'Spawn a backend using a token.'
+  static description = 'Spawn a backend using a spawn token.'
 
   static examples = [
     '<%= config.bin %> <%= command.id %> jNCuGvecEEk706SDm2xYRJc7mqplE2',
@@ -13,7 +13,7 @@ export default class Spawn extends Command {
   public async run(): Promise<void> {
     const { args } = await this.parse(Spawn)
     const api = JamsocketApi.fromEnvironment()
-    const responseBody = await api.tokenSpawn(args.token)
+    const responseBody = await api.spawnTokenSpawn(args.token)
     this.log(JSON.stringify(responseBody, null, 2))
   }
 }

--- a/src/jamsocket.ts
+++ b/src/jamsocket.ts
@@ -1,4 +1,4 @@
-import { JamsocketApi, ServiceCreateResult, ServiceListResult, SpawnRequestBody, SpawnResult, StatusMessage, TokenCreateResult, TokenRequestBody, TokenRevokeResult } from './api'
+import { JamsocketApi, ServiceCreateResult, ServiceListResult, SpawnRequestBody, SpawnResult, StatusMessage, SpawnTokenCreateResult, SpawnTokenRequestBody, SpawnTokenRevokeResult } from './api'
 import { JamsocketConfig, readJamsocketConfig } from './jamsocket-config'
 import { ContainerManager, detectContainerManager } from './container-manager'
 
@@ -80,19 +80,19 @@ export class Jamsocket {
     return this.api.status(backend, config.auth)
   }
 
-  public tokenCreate(service: string, grace?: number, port?: number, tag?: string): Promise<TokenCreateResult> {
+  public spawnTokenCreate(service: string, grace?: number, port?: number, tag?: string): Promise<SpawnTokenCreateResult> {
     const config = this.expectAuthorized()
-    const body: TokenRequestBody = {
+    const body: SpawnTokenRequestBody = {
       grace_period_seconds: grace,
       port,
       tag,
     }
 
-    return this.api.tokenCreate(config.username, service, config.auth, body)
+    return this.api.spawnTokenCreate(config.username, service, config.auth, body)
   }
 
-  public tokenRevoke(token: string): Promise<TokenRevokeResult> {
+  public spawnTokenRevoke(token: string): Promise<SpawnTokenRevokeResult> {
     const config = this.expectAuthorized()
-    return this.api.tokenRevoke(token, config.auth)
+    return this.api.spawnTokenRevoke(token, config.auth)
   }
 }


### PR DESCRIPTION
This updates the `jamsocket login` command to use our new API tokens. I decided to intentionally _not_ allow users to login with user/pass here, as I think it's too easy to confuse with the PropelAuth user/pass. Also, we want to deprecate account passwords anyway. Those who still would like to auth with user/pass can remain on the previous version of the jamsocket cli.

That said, there are a few design decisions I'm unsure about and am looking for feedback on. See inline comments below.

Also note: the `/cli-login` page - actually, even the whole Jamsocket App - is not yet implemented. That's next!