### PR TITLE
make login fetch account name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ EXAMPLES
   $ jamsocket login W3guqHFk0FJdtquC.iDxcHZr4rg1AIWPxpnk0SWHm95Vfdl
 ```
 
-_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.3.0/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.0/src/commands/login.ts)_
 
 ## `jamsocket logout`
 
@@ -86,7 +86,7 @@ EXAMPLES
   $ jamsocket logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.3.0/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.0/src/commands/logout.ts)_
 
 ## `jamsocket logs BACKEND`
 
@@ -106,7 +106,7 @@ EXAMPLES
   $ jamsocket logs f7em2
 ```
 
-_See code: [src/commands/logs.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.3.0/src/commands/logs.ts)_
+_See code: [src/commands/logs.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.0/src/commands/logs.ts)_
 
 ## `jamsocket push SERVICE IMAGE`
 
@@ -132,7 +132,7 @@ EXAMPLES
   $ jamsocket push my-service my-image -t my-tag
 ```
 
-_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.3.0/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.0/src/commands/push.ts)_
 
 ## `jamsocket service create NAME`
 
@@ -191,7 +191,7 @@ EXAMPLES
   $ jamsocket spawn my-service -t latest
 ```
 
-_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.3.0/src/commands/spawn.ts)_
+_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.0/src/commands/spawn.ts)_
 
 ## `jamsocket spawn-token create SERVICE`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -140,9 +140,11 @@ export class JamsocketApi {
   private async makeAuthenticatedRequest<T>(endpoint: string, method: HttpMethod, apiToken: string, body?: any): Promise<T> {
     const additionalHeaders = { 'Authorization': `Bearer ${apiToken}` }
     try {
-      return this.makeRequest<T>(endpoint, method, body, additionalHeaders)
+      // NOTE: this await here is required so that all the Promise "callback" logic is wrapped in this try/catch
+      return await this.makeRequest<T>(endpoint, method, body, additionalHeaders)
     } catch (error) {
       if (error instanceof HTTPError && error.code < 500) throw new AuthenticationError(error.code, error.message)
+      throw error
     }
   }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -114,7 +114,7 @@ export class JamsocketApi {
     let responseBody
     try {
       responseBody = JSON.parse(response.body)
-      // TODO: add a runtime check here to make sure the response matches the type T
+      // TODO: if possible, add a runtime check here to make sure the response matches the type T?
     } catch {}
     const isValidJSON = isJSONContentType && responseBody !== undefined
 

--- a/src/jamsocket.ts
+++ b/src/jamsocket.ts
@@ -1,5 +1,5 @@
 import { JamsocketApi, ServiceCreateResult, ServiceListResult, SpawnRequestBody, SpawnResult, StatusMessage, SpawnTokenCreateResult, SpawnTokenRequestBody, SpawnTokenRevokeResult } from './api'
-import { JamsocketConfig, readJamsocketConfig } from './jamsocket-config'
+import { JamsocketConfig, readJamsocketConfig, getRegistryAuth } from './jamsocket-config'
 import { ContainerManager, detectContainerManager } from './container-manager'
 
 export class Jamsocket {
@@ -22,7 +22,7 @@ export class Jamsocket {
 
   public async serviceImage(service: string): Promise<string> {
     const config = this.expectAuthorized()
-    const result = await this.api.serviceImage(config.username, service, config.auth)
+    const result = await this.api.serviceImage(config.account, service, config.token)
     return result.imageName
   }
 
@@ -37,7 +37,8 @@ export class Jamsocket {
     containerManager.tag(image, prefixedImage)
 
     console.log('Pushing.')
-    await containerManager.push(prefixedImage, config.auth)
+    const auth = getRegistryAuth(config.token)
+    await containerManager.push(prefixedImage, auth)
 
     console.log('Done.')
   }
@@ -52,32 +53,32 @@ export class Jamsocket {
       tag,
     }
 
-    return this.api.spawn(config.username, service, config.auth, body)
+    return this.api.spawn(config.account, service, config.token, body)
   }
 
   public serviceCreate(service: string): Promise<ServiceCreateResult> {
     const config = this.expectAuthorized()
-    return this.api.serviceCreate(config.username, service, config.auth)
+    return this.api.serviceCreate(config.account, service, config.token)
   }
 
   public serviceList(): Promise<ServiceListResult> {
     const config = this.expectAuthorized()
-    return this.api.serviceList(config.username, config.auth)
+    return this.api.serviceList(config.account, config.token)
   }
 
   public streamLogs(backend: string, callback: (v: string) => void): Promise<void> {
     const config = this.expectAuthorized()
-    return this.api.streamLogs(backend, config.auth, callback)
+    return this.api.streamLogs(backend, config.token, callback)
   }
 
   public streamStatus(backend: string, callback: (v: StatusMessage) => void): Promise<void> {
     const config = this.expectAuthorized()
-    return this.api.streamStatus(backend, config.auth, callback)
+    return this.api.streamStatus(backend, config.token, callback)
   }
 
   public status(backend: string): Promise<StatusMessage> {
     const config = this.expectAuthorized()
-    return this.api.status(backend, config.auth)
+    return this.api.status(backend, config.token)
   }
 
   public spawnTokenCreate(service: string, grace?: number, port?: number, tag?: string): Promise<SpawnTokenCreateResult> {
@@ -88,11 +89,11 @@ export class Jamsocket {
       tag,
     }
 
-    return this.api.spawnTokenCreate(config.username, service, config.auth, body)
+    return this.api.spawnTokenCreate(config.account, service, config.token, body)
   }
 
-  public spawnTokenRevoke(token: string): Promise<SpawnTokenRevokeResult> {
+  public spawnTokenRevoke(spawnToken: string): Promise<SpawnTokenRevokeResult> {
     const config = this.expectAuthorized()
-    return this.api.spawnTokenRevoke(token, config.auth)
+    return this.api.spawnTokenRevoke(spawnToken, config.token)
   }
 }


### PR DESCRIPTION
This PR does a few things:

* fetches `account` name with provided token in the login command
* fixes a bug where some authentication exceptions weren't getting caught correctly
* updates the config to store `account` and `token` properties
* adds generic types to the API functions
* renamed some `token` vars to disambiguate between spawn tokens and api tokens