### PR TITLE
update api domain and paths to point to api.jamsocket.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ EXAMPLES
   $ jamsocket login W3guqHFk0FJdtquC.iDxcHZr4rg1AIWPxpnk0SWHm95Vfdl
 ```
 
-_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.0/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.1/src/commands/login.ts)_
 
 ## `jamsocket logout`
 
@@ -86,7 +86,7 @@ EXAMPLES
   $ jamsocket logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.0/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.1/src/commands/logout.ts)_
 
 ## `jamsocket logs BACKEND`
 
@@ -106,7 +106,7 @@ EXAMPLES
   $ jamsocket logs f7em2
 ```
 
-_See code: [src/commands/logs.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.0/src/commands/logs.ts)_
+_See code: [src/commands/logs.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.1/src/commands/logs.ts)_
 
 ## `jamsocket push SERVICE IMAGE`
 
@@ -132,7 +132,7 @@ EXAMPLES
   $ jamsocket push my-service my-image -t my-tag
 ```
 
-_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.0/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.1/src/commands/push.ts)_
 
 ## `jamsocket service create NAME`
 
@@ -191,7 +191,7 @@ EXAMPLES
   $ jamsocket spawn my-service -t latest
 ```
 
-_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.0/src/commands/spawn.ts)_
+_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.4.1/src/commands/spawn.ts)_
 
 ## `jamsocket spawn-token create SERVICE`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -79,8 +79,7 @@ export class JamsocketApi {
     const override = process.env.JAMSOCKET_SERVER_API
     let apiBase
     if (override === undefined) {
-      // Will switch back to https://jamsocket.dev once we complete the migration to Jamsocket's version p2
-      apiBase = 'https://new.jamsocket.dev'
+      apiBase = 'https://api.jamsocket.com'
     } else {
       console.warn(`Using Jamsocket server override: ${override}`)
       apiBase = override
@@ -158,39 +157,39 @@ export class JamsocketApi {
   }
 
   public checkAuth(apiToken: string): Promise<CheckAuthResult> {
-    const url = '/api/auth'
+    const url = '/auth'
     return this.makeAuthenticatedRequest<CheckAuthResult>(url, HttpMethod.Get, apiToken)
   }
 
   public serviceImage(username: string, serviceName: string, apiToken: string): Promise<ServiceImageResult> {
-    const url = `/api/user/${username}/service/${serviceName}/image`
+    const url = `/user/${username}/service/${serviceName}/image`
     return this.makeAuthenticatedRequest<ServiceImageResult>(url, HttpMethod.Get, apiToken)
   }
 
   public serviceCreate(username: string, name: string, apiToken: string): Promise<ServiceCreateResult> {
-    const url = `/api/user/${username}/service`
+    const url = `/user/${username}/service`
     return this.makeAuthenticatedRequest<ServiceCreateResult>(url, HttpMethod.Post, apiToken, {
       name,
     })
   }
 
   public serviceList(username: string, apiToken: string): Promise<ServiceListResult> {
-    const url = `/api/user/${username}/services`
+    const url = `/user/${username}/services`
     return this.makeAuthenticatedRequest<ServiceListResult>(url, HttpMethod.Get, apiToken)
   }
 
   public spawn(username: string, serviceName: string, apiToken: string, body: SpawnRequestBody): Promise<SpawnResult> {
-    const url = `/api/user/${username}/service/${serviceName}/spawn`
+    const url = `/user/${username}/service/${serviceName}/spawn`
     return this.makeAuthenticatedRequest<SpawnResult>(url, HttpMethod.Post, apiToken, body)
   }
 
   public streamLogs(backend: string, apiToken: string, callback: (line: string) => void): Promise<void> {
-    const url = `/api/backend/${backend}/logs`
+    const url = `/backend/${backend}/logs`
     return this.makeAuthenticatedStreamRequest(url, apiToken, callback)
   }
 
   public streamStatus(backend: string, apiToken: string, callback: (statusMessage: StatusMessage) => void): Promise<void> {
-    const url = `/api/backend/${backend}/status/stream`
+    const url = `/backend/${backend}/status/stream`
     const wrappedCallback = (line: string) => {
       const val = JSON.parse(line)
       callback({
@@ -202,22 +201,22 @@ export class JamsocketApi {
   }
 
   public async status(backend: string, apiToken: string): Promise<StatusMessage> {
-    const url = `/api/backend/${backend}/status`
+    const url = `/backend/${backend}/status`
     return this.makeAuthenticatedRequest<StatusMessage>(url, HttpMethod.Get, apiToken)
   }
 
   public async spawnTokenCreate(username: string, serviceName: string, apiToken: string, body: SpawnTokenRequestBody): Promise<SpawnTokenCreateResult> {
-    const url = `/api/user/${username}/service/${serviceName}/token`
+    const url = `/user/${username}/service/${serviceName}/token`
     return this.makeAuthenticatedRequest<SpawnTokenCreateResult>(url, HttpMethod.Post, apiToken, body)
   }
 
   public async spawnTokenRevoke(spawnToken: string, apiToken: string): Promise<SpawnTokenRevokeResult> {
-    const url = `/api/token/${spawnToken}`
+    const url = `/token/${spawnToken}`
     return this.makeAuthenticatedRequest<SpawnTokenRevokeResult>(url, HttpMethod.Delete, apiToken)
   }
 
   public async spawnTokenSpawn(spawnToken: string): Promise<SpawnResult> {
-    const url = `/api/token/${spawnToken}/spawn`
+    const url = `/token/${spawnToken}/spawn`
     return this.makeRequest<SpawnResult>(url, HttpMethod.Post, {})
   }
 }


### PR DESCRIPTION
This updates the Jamsocket CLI to use the new API domain: `api.jamsocket.com` and strips the `/api` prefix from the paths.

Once https://github.com/drifting-in-space/p2/pull/261 lands, we can land this and publish this commit as `v0.4.1` / `next`. And we should apply the same changes on top of `v0.2.0` (the current `latest`) and publish those changes as `v0.2.1` / `latest`. Then, both `latest` and `next` will point to `api.jamsocket.com`, with the only difference being the changes to `jamsocket login` to use API tokens, which hasn't been fully released yet. When that gets released, we can set `v0.4.1` to `latest`.