### PR TITLE
add user-agent to outgoing requests from jamsocket-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "@types/date-fns": "^2.6.0",
         "chalk": "^4",
         "date-fns": "^2.29.3",
-        "inquirer": "^8.2.5"
+        "inquirer": "^8.2.5",
+        "is-wsl": "^2.2.0"
       },
       "bin": {
         "jamsocket": "bin/run"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@types/date-fns": "^2.6.0",
     "chalk": "^4",
     "date-fns": "^2.29.3",
-    "inquirer": "^8.2.5"
+    "inquirer": "^8.2.5",
+    "is-wsl": "^2.2.0"
   },
   "devDependencies": {
     "@types/inquirer": "^8.2.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "target": "es2019",
     "esModuleInterop": true,
+    "resolveJsonModule": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
This adds a `User-Agent` header to all HTTP requests that looks like this:
```
jamsocket-cli/0.4.6 linux-x64 node-v18.4.0
```
