### PR TITLE
add a backend list command

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
       "service": {
         "description": "manage jamsocket services"
       },
+      "backend": {
+        "description": "manage jamsocket backends"
+      },
       "token": {
         "description": "manage spawn tokens"
       }

--- a/src/api.ts
+++ b/src/api.ts
@@ -76,8 +76,8 @@ export type BackendWithStatus = {
   service_name: string
   cluster_name: string
   account_name: string
-  status?: string | null
-  status_timestamp?: string | null
+  status?: string
+  status_timestamp?: string
 }
 
 export interface RunningBackendsResult {

--- a/src/api.ts
+++ b/src/api.ts
@@ -70,6 +70,20 @@ export interface SpawnTokenRevokeResult {
   status: 'ok',
 }
 
+export type BackendWithStatus = {
+  name: string
+  created_at: string
+  service_name: string
+  cluster_name: string
+  account_name: string
+  status?: string | null
+  status_timestamp?: string | null
+}
+
+export interface RunningBackendsResult {
+  running_backends: BackendWithStatus[]
+}
+
 export interface TerminateResult {
   status: 'ok',
 }
@@ -239,6 +253,11 @@ export class JamsocketApi {
   public spawn(username: string, serviceName: string, authToken: string, body: SpawnRequestBody): Promise<SpawnResult> {
     const url = `/user/${username}/service/${serviceName}/spawn`
     return this.makeAuthenticatedRequest<SpawnResult>(url, HttpMethod.Post, authToken, body)
+  }
+
+  public listRunningBackends(username: string, authToken: string): Promise<RunningBackendsResult> {
+    const url = `/user/${username}/backends`
+    return this.makeAuthenticatedRequest<RunningBackendsResult>(url, HttpMethod.Get, authToken)
   }
 
   public streamLogs(backend: string, authToken: string, callback: (line: string) => void): Promise<void> {

--- a/src/commands/backend/list.ts
+++ b/src/commands/backend/list.ts
@@ -1,15 +1,7 @@
 import { Command, CliUx } from '@oclif/core'
+import { formatDistanceToNow } from 'date-fns'
 import { BackendWithStatus } from '../../api'
 import { Jamsocket } from '../../jamsocket'
-
-function formatDate(date: string): string {
-  const d = new Date(date)
-  const tzOffset = d.getTimezoneOffset()
-  const hours = Math.abs(Math.floor(tzOffset / 60)).toString().padStart(2, '0')
-  const mins = (Math.abs(tzOffset) % 60).toString().padStart(2, '0')
-  const sign = tzOffset < 0 ? '-' : '+'
-  return `${d.toLocaleDateString()} ${d.toLocaleTimeString()} (GMT${sign}${hours}:${mins})`
-}
 
 export default class List extends Command {
   static description = 'List running backends for the logged-in user'
@@ -33,13 +25,17 @@ export default class List extends Command {
       name: { header: 'Name' },
       created_at: {
         header: 'Created',
-        get: row => formatDate(row.created_at),
+        get: row => formatDistanceToNow(new Date(row.created_at)),
       },
       account_name: { header: 'Account' },
       service_name: { header: 'Service' },
       status: {
         header: 'Status',
-        get: row => row.status ? `${row.status} (${formatDate(row.status_timestamp!)})` : '-',
+        get: row => {
+          return row.status ?
+            `${row.status} (${formatDistanceToNow(new Date(row.status_timestamp!))})` :
+            '-'
+        },
       },
     }, {
       printLine: this.log.bind(this),

--- a/src/commands/backend/list.ts
+++ b/src/commands/backend/list.ts
@@ -1,0 +1,49 @@
+import { Command, CliUx } from '@oclif/core'
+import { BackendWithStatus } from '../../api'
+import { Jamsocket } from '../../jamsocket'
+
+function formatDate(date: string): string {
+  const d = new Date(date)
+  const tzOffset = d.getTimezoneOffset()
+  const hours = Math.abs(Math.floor(tzOffset / 60)).toString().padStart(2, '0')
+  const mins = (Math.abs(tzOffset) % 60).toString().padStart(2, '0')
+  const sign = tzOffset < 0 ? '-' : '+'
+  return `${d.toLocaleDateString()} ${d.toLocaleTimeString()} (GMT${sign}${hours}:${mins})`
+}
+
+export default class List extends Command {
+  static description = 'List running backends for the logged-in user'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+  ]
+
+  public async run(): Promise<void> {
+    const jamsocket = Jamsocket.fromEnvironment()
+    const responseBody = await jamsocket.listRunningBackends()
+
+    if (responseBody.running_backends.length === 0) {
+      this.log('No running backends found.\n')
+      return
+    }
+
+    this.log()
+    this.log('Found the following running backends:\n')
+    CliUx.ux.table<BackendWithStatus>(responseBody.running_backends, {
+      name: { header: 'Name' },
+      created_at: {
+        header: 'Created',
+        get: row => formatDate(row.created_at),
+      },
+      account_name: { header: 'Account' },
+      service_name: { header: 'Service' },
+      status: {
+        header: 'Status',
+        get: row => row.status ? `${row.status} (${formatDate(row.status_timestamp!)})` : '-',
+      },
+    }, {
+      printLine: this.log.bind(this),
+    })
+    this.log()
+  }
+}

--- a/src/jamsocket.ts
+++ b/src/jamsocket.ts
@@ -1,4 +1,4 @@
-import { JamsocketApi, SpawnRequestBody, SpawnResult, StatusMessage, TerminateResult } from './api'
+import { JamsocketApi, RunningBackendsResult, SpawnRequestBody, SpawnResult, StatusMessage, TerminateResult } from './api'
 import type { SpawnTokenCreateResult, SpawnTokenRequestBody, SpawnTokenRevokeResult } from './api'
 import type { ServiceCreateResult, ServiceListResult, ServiceInfoResult, ServiceDeleteResult } from './api'
 import { JamsocketConfig } from './jamsocket-config'
@@ -62,6 +62,11 @@ export class Jamsocket {
     const config = this.expectAuthorized()
 
     return this.api.terminate(backend, config.getAccessToken())
+  }
+
+  public listRunningBackends(): Promise<RunningBackendsResult> {
+    const config = this.expectAuthorized()
+    return this.api.listRunningBackends(config.getAccount(), config.getAccessToken())
   }
 
   public serviceCreate(service: string): Promise<ServiceCreateResult> {


### PR DESCRIPTION
This adds the topic `backend` plus a `list` subcommand for it that lists the running backends. This is necessary for users to be able to control the number of running backends they have as they have spawn limits applied to them.

The command looks like this:

```
$ jamsocket backend list

Currently running backends:

 Name  Created  Account              Service   Status           
 ───── ──────── ──────────────────── ───────── ──────────────── 
 otjop 1 minute test-account-8917364 drop-four Ready (1 minute) 
 wwrwq 1 minute test-account-8917364 drop-four Ready (1 minute) 
 fmrwr 1 minute test-account-8917364 drop-four Ready (1 minute) 
```

