### PR TITLE
show error when docker image is not found on push

### DIFF
--- a/src/docker.ts
+++ b/src/docker.ts
@@ -7,7 +7,7 @@ export function getImagePlatform(imageName: string): { os: string, arch: string 
   const getPlatform = spawnSync('docker', ['image', 'inspect', '--format', '{{.Os}} {{.Architecture}}', imageName])
   if (getPlatform.status !== 0) {
     const stderr = getPlatform.stderr.toString().trim()
-    throw new Error(`Encountered docker error while checking image platform:\n${stderr}`)
+    throw new Error(`Encountered docker error:\n${stderr}`)
   }
   const stdout = getPlatform.stdout.toString().trim()
   const [os, arch] = stdout.split(' ').map(s => s.trim())

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -5,7 +5,11 @@ import { JAMSOCKET_CONFIG_DIR } from './jamsocket-config'
 
 export function getImagePlatform(imageName: string): { os: string, arch: string } {
   const getPlatform = spawnSync('docker', ['image', 'inspect', '--format', '{{.Os}} {{.Architecture}}', imageName])
-  const stdout = getPlatform.stdout.toString()
+  if (getPlatform.status !== 0) {
+    const stderr = getPlatform.stderr.toString().trim()
+    throw new Error(`Encountered docker error while checking image platform:\n${stderr}`)
+  }
+  const stdout = getPlatform.stdout.toString().trim()
   const [os, arch] = stdout.split(' ').map(s => s.trim())
   return { os, arch }
 }


### PR DESCRIPTION
This fixes a bug where if someone tries to push an image that doesn't exist, the CLI would complain about the image being built with the wrong arch.