### PR TITLE
v0.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ EXAMPLES
   $ jamsocket login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.3/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.4/src/commands/login.ts)_
 
 ## `jamsocket logout`
 
@@ -187,7 +187,7 @@ EXAMPLES
   $ jamsocket logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.3/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.4/src/commands/logout.ts)_
 
 ## `jamsocket logs BACKEND`
 
@@ -234,7 +234,7 @@ EXAMPLES
   $ jamsocket push my-service my-image -t my-tag
 ```
 
-_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.3/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.4/src/commands/push.ts)_
 
 ## `jamsocket service create NAME`
 
@@ -326,7 +326,7 @@ EXAMPLES
   $ jamsocket spawn my-service -t latest
 ```
 
-_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.3/src/commands/spawn.ts)_
+_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.4/src/commands/spawn.ts)_
 
 ## `jamsocket spawn-token create SERVICE`
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ EXAMPLES
 
 ## `jamsocket spawn SERVICE`
 
-Spawns a session-lived application backend from the provided docker image
+Spawns a session backend from the provided docker image
 
 ```
 USAGE
@@ -314,7 +314,7 @@ FLAGS
   -t, --tag=<value>           optional tag for the service to spawn (default is latest)
 
 DESCRIPTION
-  Spawns a session-lived application backend from the provided docker image
+  Spawns a session backend from the provided docker image
 
 EXAMPLES
   $ jamsocket spawn my-service

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,9 @@
     "jamsocket",
     "plane",
     "spawner",
-    "session-lived backends",
-    "session-lived application backends",
+    "session backends",
+    "session lived backends",
+    "session lived application backends",
     "drifting in space",
     "docker"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/src/commands/spawn.ts
+++ b/src/commands/spawn.ts
@@ -7,7 +7,7 @@ import { blue, lightBlue } from '../formatting'
 const MAX_PORT = (2 ** 16) - 1
 
 export default class Spawn extends Command {
-  static description = 'Spawns a session-lived application backend from the provided docker image'
+  static description = 'Spawns a session backend from the provided docker image'
 
   static examples = [
     '<%= config.bin %> <%= command.id %> my-service',


### PR DESCRIPTION
Updates to v0.6.4 (which was published with the tag `next` - so you can use it with `npx jamsocket@next spawn hello-world --lock abc123`