### PR TITLE
first pass at an experimental dev CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ EXAMPLES
   $ jamsocket dev
 ```
 
-_See code: [src/commands/dev.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-0/src/commands/dev.ts)_
+_See code: [src/commands/dev.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-1/src/commands/dev.ts)_
 
 ## `jamsocket help [COMMAND]`
 
@@ -185,7 +185,7 @@ EXAMPLES
   $ jamsocket login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-0/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-1/src/commands/login.ts)_
 
 ## `jamsocket logout`
 
@@ -202,7 +202,7 @@ EXAMPLES
   $ jamsocket logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-0/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-1/src/commands/logout.ts)_
 
 ## `jamsocket logs BACKEND`
 
@@ -249,7 +249,7 @@ EXAMPLES
   $ jamsocket push my-service my-image -t my-tag
 ```
 
-_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-0/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-1/src/commands/push.ts)_
 
 ## `jamsocket service create NAME`
 
@@ -341,7 +341,7 @@ EXAMPLES
   $ jamsocket spawn my-service -t latest
 ```
 
-_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-0/src/commands/spawn.ts)_
+_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-1/src/commands/spawn.ts)_
 
 ## `jamsocket terminate BACKEND`
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If you want to use the Jamsocket CLI from an automated environment (e.g. a CI/CD
 * [`jamsocket backend logs BACKEND`](#jamsocket-backend-logs-backend)
 * [`jamsocket backend metrics BACKEND`](#jamsocket-backend-metrics-backend)
 * [`jamsocket backend terminate BACKEND`](#jamsocket-backend-terminate-backend)
+* [`jamsocket dev`](#jamsocket-dev)
 * [`jamsocket help [COMMAND]`](#jamsocket-help-command)
 * [`jamsocket login`](#jamsocket-login)
 * [`jamsocket logout`](#jamsocket-logout)
@@ -129,6 +130,23 @@ EXAMPLES
   $ jamsocket backend terminate a8m32q
 ```
 
+## `jamsocket dev`
+
+(Experimental) Starts a jamsocket dev server
+
+```
+USAGE
+  $ jamsocket dev
+
+DESCRIPTION
+  (Experimental) Starts a jamsocket dev server
+
+EXAMPLES
+  $ jamsocket dev
+```
+
+_See code: [src/commands/dev.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-0/src/commands/dev.ts)_
+
 ## `jamsocket help [COMMAND]`
 
 Display help for jamsocket.
@@ -167,7 +185,7 @@ EXAMPLES
   $ jamsocket login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.4/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-0/src/commands/login.ts)_
 
 ## `jamsocket logout`
 
@@ -184,7 +202,7 @@ EXAMPLES
   $ jamsocket logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.4/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-0/src/commands/logout.ts)_
 
 ## `jamsocket logs BACKEND`
 
@@ -231,7 +249,7 @@ EXAMPLES
   $ jamsocket push my-service my-image -t my-tag
 ```
 
-_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.4/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-0/src/commands/push.ts)_
 
 ## `jamsocket service create NAME`
 
@@ -323,7 +341,7 @@ EXAMPLES
   $ jamsocket spawn my-service -t latest
 ```
 
-_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.4/src/commands/spawn.ts)_
+_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.6.5-0/src/commands/spawn.ts)_
 
 ## `jamsocket terminate BACKEND`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.6.5-0",
+  "version": "0.6.5-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.6.5-0",
+      "version": "0.6.5-1",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,11 @@
         "@types/chalk": "^2.2.0",
         "@types/date-fns": "^2.6.0",
         "chalk": "^4",
+        "chokidar": "^3.5.3",
         "date-fns": "^2.29.3",
         "inquirer": "^8.2.5",
-        "is-wsl": "^2.2.0"
+        "is-wsl": "^2.2.0",
+        "string-length": "4.0.2"
       },
       "bin": {
         "jamsocket": "bin/run"
@@ -924,6 +926,24 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@oclif/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/@oclif/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@oclif/linewrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
@@ -1565,6 +1585,18 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -1730,6 +1762,14 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/binaryextensions": {
@@ -1956,10 +1996,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/chownr": {
       "version": "1.1.4",
@@ -2039,6 +2113,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/cli-progress/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/cli-progress/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-spinners": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
@@ -2079,6 +2171,26 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/clone": {
@@ -2479,11 +2591,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
       "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
       "dev": true
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -3422,6 +3529,19 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3452,6 +3572,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/gauge/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/gauge/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/gensync": {
@@ -3874,12 +4014,30 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/inquirer/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
     "node_modules/inquirer/node_modules/rxjs": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
       "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/interpret": {
@@ -3901,6 +4059,17 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/is-builtin-module": {
       "version": "3.1.0",
@@ -4795,6 +4964,12 @@
         "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
+    "node_modules/node-gyp/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "node_modules/node-gyp/node_modules/gauge": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
@@ -4827,6 +5002,20 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/node-releases": {
@@ -4869,7 +5058,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6209,6 +6397,17 @@
         "once": "^1.3.0"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -6681,17 +6880,16 @@
         }
       ]
     },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/strip-ansi": {
@@ -6862,11 +7060,31 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "node_modules/table/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/taketalk": {
       "version": "1.0.0",
@@ -7369,12 +7587,50 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/wide-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wide-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/widest-line": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "dependencies": {
         "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -7403,6 +7659,24 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {
@@ -7501,6 +7775,26 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yeoman-environment": {
@@ -8685,6 +8979,23 @@
         "tslib": "^2.3.1",
         "widest-line": "^3.1.0",
         "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
       }
     },
     "@oclif/linewrap": {
@@ -9178,6 +9489,15 @@
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
     },
+    "anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -9305,6 +9625,11 @@
           }
         }
       }
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "binaryextensions": {
       "version": "4.18.0",
@@ -9460,10 +9785,30 @@
         }
       }
     },
+    "char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
+    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
     },
     "chownr": {
       "version": "1.1.4",
@@ -9522,6 +9867,23 @@
       "integrity": "sha512-TTMA2LHrYaZeNMcgZGO10oYqj9hvd03pltNtVbu4ddeyDTHlYV7gWxsFiuvaQlgwMBFCv1TukcjiODWFlb16tQ==",
       "requires": {
         "string-width": "^4.2.3"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
       }
     },
     "cli-spinners": {
@@ -9552,6 +9914,25 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
       }
     },
     "clone": {
@@ -9866,11 +10247,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
       "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==",
       "dev": true
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encoding": {
       "version": "0.1.13",
@@ -10593,6 +10969,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -10620,6 +11002,25 @@
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
       }
     },
     "gensync": {
@@ -10937,12 +11338,27 @@
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
         "rxjs": {
           "version": "7.5.7",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
           "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
           "requires": {
             "tslib": "^2.1.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
           }
         }
       }
@@ -10963,6 +11379,14 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
     },
     "is-builtin-module": {
       "version": "3.1.0",
@@ -11631,6 +12055,12 @@
             "readable-stream": "^3.6.0"
           }
         },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
         "gauge": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
@@ -11657,6 +12087,17 @@
             "console-control-strings": "^1.1.0",
             "gauge": "^4.0.3",
             "set-blocking": "^2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
           }
         }
       }
@@ -11691,8 +12132,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "npm-bundled": {
       "version": "1.1.2",
@@ -12722,6 +13162,14 @@
         "once": "^1.3.0"
       }
     },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -13062,14 +13510,13 @@
         }
       }
     },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+    "string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
       "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
       }
     },
     "strip-ansi": {
@@ -13192,11 +13639,28 @@
             "uri-js": "^4.2.2"
           }
         },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
         }
       }
     },
@@ -13601,6 +14065,25 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
       }
     },
     "widest-line": {
@@ -13609,6 +14092,23 @@
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "requires": {
         "string-width": "^4.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
       }
     },
     "word-wrap": {
@@ -13625,6 +14125,23 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
       }
     },
     "wrappy": {
@@ -13699,6 +14216,25 @@
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
         "yargs-parser": "^21.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        }
       }
     },
     "yargs-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.6.4",
+  "version": "0.6.5-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.6.4",
+      "version": "0.6.5-0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.6.4",
+  "version": "0.6.5-0",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "@types/chalk": "^2.2.0",
     "@types/date-fns": "^2.6.0",
     "chalk": "^4",
+    "chokidar": "^3.5.3",
     "date-fns": "^2.29.3",
     "inquirer": "^8.2.5",
-    "is-wsl": "^2.2.0"
+    "is-wsl": "^2.2.0",
+    "string-length": "4.0.2"
   },
   "devDependencies": {
     "@types/inquirer": "^8.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.6.5-0",
+  "version": "0.6.5-1",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { eventStream, request, Headers } from './request'
+import { eventStream, request, Headers, EventStreamReturn } from './request'
 import * as https from 'https'
 
 enum HttpMethod {
@@ -211,7 +211,7 @@ export class JamsocketApi {
     }
   }
 
-  private async makeAuthenticatedStreamRequest(endpoint: string, authToken: string, callback: (line: string) => void): Promise<void> {
+  private makeAuthenticatedStreamRequest(endpoint: string, authToken: string, callback: (line: string) => void): EventStreamReturn {
     const url = `${this.apiBase}${endpoint}`
     return eventStream(url, {
       ...this.options,
@@ -262,17 +262,17 @@ export class JamsocketApi {
     return this.makeAuthenticatedRequest<RunningBackendsResult>(url, HttpMethod.Get, authToken)
   }
 
-  public streamLogs(backend: string, authToken: string, callback: (line: string) => void): Promise<void> {
+  public streamLogs(backend: string, authToken: string, callback: (line: string) => void): EventStreamReturn {
     const url = `/backend/${backend}/logs`
     return this.makeAuthenticatedStreamRequest(url, authToken, callback)
   }
 
-  public streamMetrics(backend: string, authToken: string, callback: (line: string) => void): Promise<void> {
+  public streamMetrics(backend: string, authToken: string, callback: (line: string) => void): EventStreamReturn {
     const url = `/backend/${backend}/metrics/stream`
     return this.makeAuthenticatedStreamRequest(url, authToken, callback)
   }
 
-  public streamStatus(backend: string, authToken: string, callback: (statusMessage: StatusMessage) => void): Promise<void> {
+  public streamStatus(backend: string, authToken: string, callback: (statusMessage: StatusMessage) => void): EventStreamReturn {
     const url = `/backend/${backend}/status/stream`
     const wrappedCallback = (line: string) => {
       const val = JSON.parse(line)
@@ -319,12 +319,13 @@ export class JamsocketApi {
     const url = `${this.apiBase}${endpoint}`
     // right now, this stream only returns a single message and then closes
     return new Promise(resolve => {
-      eventStream(url, {
+      const stream = eventStream(url, {
         ...this.options,
         method: HttpMethod.Get,
       }, (line: string) => {
         const val = JSON.parse(line)
         resolve(val.status === 'ok')
+        stream.close()
       })
     })
   }

--- a/src/commands/backend/logs.ts
+++ b/src/commands/backend/logs.ts
@@ -16,8 +16,10 @@ export default class Logs extends Command {
       const jamsocket = Jamsocket.fromEnvironment()
       const { args } = await this.parse(Logs)
 
-      await jamsocket.streamLogs(args.backend, line => {
+      const logsStream = jamsocket.streamLogs(args.backend, line => {
         this.log(line)
       })
+
+      await logsStream.onClose
     }
 }

--- a/src/commands/backend/logs.ts
+++ b/src/commands/backend/logs.ts
@@ -20,6 +20,6 @@ export default class Logs extends Command {
         this.log(line)
       })
 
-      await logsStream.onClose
+      await logsStream.closed
     }
 }

--- a/src/commands/backend/metrics.ts
+++ b/src/commands/backend/metrics.ts
@@ -39,7 +39,7 @@ export default class Metrics extends Command {
 
     this.log(chalk.bold(headers.join('\t')))
 
-    await jamsocket.streamMetrics(args.backend, line => {
+    const metricsStream = jamsocket.streamMetrics(args.backend, line => {
       const metrics: BackendMetrics = JSON.parse(line)
       const cpu_util = (metrics.cpu_used / metrics.sys_cpu) * 100
       const values = [
@@ -49,5 +49,7 @@ export default class Metrics extends Command {
       ]
       process.stdout.write(resetLine + formatRow(values))
     })
+
+    await metricsStream.onClose
   }
 }

--- a/src/commands/backend/metrics.ts
+++ b/src/commands/backend/metrics.ts
@@ -50,6 +50,6 @@ export default class Metrics extends Command {
       process.stdout.write(resetLine + formatRow(values))
     })
 
-    await metricsStream.onClose
+    await metricsStream.closed
   }
 }

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -5,7 +5,7 @@ import { Jamsocket } from '../jamsocket'
 import DevServer from '../dev-server'
 
 export default class Dev extends Command {
-  static description = 'Starts a jamsocket dev server'
+  static description = '(Experimental) Starts a jamsocket dev server'
   static examples = ['<%= config.bin %> <%= command.id %>']
 
   public async run(): Promise<void> {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -5,7 +5,7 @@ import { Jamsocket } from '../jamsocket'
 import DevServer from '../dev-server'
 
 export default class Dev extends Command {
-  static description = '(Experimental) Starts a jamsocket dev server'
+  static description = '(Experimental) Starts a jamsocket dev server.'
   static examples = ['<%= config.bin %> <%= command.id %>']
 
   public async run(): Promise<void> {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,0 +1,31 @@
+import { existsSync } from 'fs'
+import path from 'path'
+import { Command } from '@oclif/core'
+import { Jamsocket } from '../jamsocket'
+import { buildImage } from '../docker'
+
+export default class Dev extends Command {
+  static description = 'Starts a jamsocket dev server'
+  static examples = ['<%= config.bin %> <%= command.id %>']
+
+  public async run(): Promise<void> {
+    const jamsocket = Jamsocket.fromEnvironment()
+    const { dockerfile, service } = loadProjectConfig()
+
+    const imageId = buildImage(dockerfile)
+    await jamsocket.push(service, imageId)
+
+    this.log('Built and pushed image to registry. ImageID:', imageId)
+  }
+}
+
+const PROJECT_CONFIG_PATH = path.resolve(process.cwd(), 'jamsocket.config.js')
+
+function loadProjectConfig(): { dockerfile: string, service: string } {
+  if (!existsSync(PROJECT_CONFIG_PATH)) throw new Error('No jamsocket.config.js found in current directory')
+  const { dockerfile, service } = require(PROJECT_CONFIG_PATH)
+  return {
+    dockerfile: path.resolve(process.cwd(), dockerfile),
+    service,
+  }
+}

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -6,7 +6,7 @@ import { getImagePlatform } from '../docker'
 import { lightMagenta } from '../formatting'
 
 export default class Push extends Command {
-  static description = 'Pushes a docker image to the jamcr.io container registry under your logged in user\'s name'
+  static description = 'Pushes a docker image to the jamcr.io container registry under your logged in user\'s name.'
 
   static examples = [
     '<%= config.bin %> <%= command.id %> my-service my-image',

--- a/src/commands/spawn.ts
+++ b/src/commands/spawn.ts
@@ -7,7 +7,7 @@ import { blue, lightBlue } from '../formatting'
 const MAX_PORT = (2 ** 16) - 1
 
 export default class Spawn extends Command {
-  static description = 'Spawns a session backend from the provided docker image'
+  static description = 'Spawns a session backend from the provided docker image.'
 
   static examples = [
     '<%= config.bin %> <%= command.id %> my-service',

--- a/src/dev-server/index.ts
+++ b/src/dev-server/index.ts
@@ -243,27 +243,22 @@ export default class DevServer {
       const reqAccount = match[1]
       const reqService = match[2]
 
+      // NOTE: the service used with the dev CLI should be a service that is just for development
+      // How do we enforce this or guide users to do this? Maybe we should make dev/prod environments
+      // first-class concepts for Jamsocket services?
       if (service !== reqService) {
-        // TODO: make this a warning
-        this.updateFooterAndLog([`Request for service ${reqService} does not match service in config (${service}). Blocking spawn.`])
+        this.updateFooterAndLog([chalk.red`Warning: Request for service ${reqService} does not match service in config (${service}). Blocking spawn.`])
         res.writeHead(401)
         res.end()
         return
       }
 
       if (account !== reqAccount) {
-        // TODO: make this a warning
-        this.updateFooterAndLog(['Request for account does not match logged-in account. Blocking spawn.'])
+        this.updateFooterAndLog([chalk.red`Warning: Request for account does not match logged-in account. Blocking spawn.`])
         res.writeHead(401)
         res.end()
         return
       }
-
-      /*
-        * TODO: The service really should be a development service, not a production one,
-        *       otherwise these pushes could break the production service.
-        *       Maybe use a special "development" tag for these?
-        */
 
       const text = await readBody(req)
       let body: Record<string, any> = {}
@@ -313,8 +308,7 @@ export default class DevServer {
       }
       const backend = this.devBackends.get(result.name)!
       if (backend.imageId !== imageId) {
-        // TODO: make this a warning
-        this.updateFooterAndLog(['Spawn with lock returned a running backend with an outdated version of the session backend code. Blocking spawn.'])
+        this.updateFooterAndLog([chalk.red`Warning: Spawn with lock returned a running backend with an outdated version of the session backend code. Blocking spawn.`])
         return new Error('dev-server spawn proxy: Spawn with lock returned a running backend with an outdated version of the session backend code. Blocking spawn.')
       }
     } else if (result.spawned) {
@@ -332,8 +326,7 @@ export default class DevServer {
       })
       this.updateFooterAndLog(['', `Spawned backend: ${result.name}`])
     } else {
-      // TODO: make this a warning
-      this.updateFooterAndLog(['Spawn with lock returned a running backend that was not originally spawned by this dev server. This may be dangerous. Blocking spawn.'])
+      this.updateFooterAndLog([chalk.red`Warning: Spawn with lock returned a running backend that was not originally spawned by this dev server. This may be dangerous. Blocking spawn.`])
       return new Error('dev-server spawn proxy: Spawn with lock returned a running backend that was not originally spawned by this dev server. This may be dangerous. Blocking spawn.')
     }
 

--- a/src/dev-server/index.ts
+++ b/src/dev-server/index.ts
@@ -1,0 +1,355 @@
+import path from 'path'
+import http from 'http'
+import chalk from 'chalk'
+import stringLength from 'string-length'
+import chokidar from 'chokidar'
+import { formatDistanceToNow } from 'date-fns'
+import { CliUx } from '@oclif/core'
+import { Jamsocket } from '../jamsocket'
+import { buildImage } from '../docker'
+import { SpawnResult, SpawnRequestBody } from '../api'
+
+type Color = 'cyan' | 'magenta' | 'yellow' | 'blue'
+
+type Backend = {
+  spawnResult: SpawnResult,
+  imageId: string,
+  spawnTime: number,
+  lastStatus: string | null,
+  lock: string | null,
+  isStreaming: boolean,
+  color: Color,
+}
+
+const BACKEND_LOG_COLORS: Color[] = ['cyan', 'magenta', 'yellow', 'blue']
+
+type Options = {
+  dockerfile: string,
+  service: string,
+  account: string,
+  watch?: string[],
+}
+
+export default class DevServer {
+  currentImageId: string | null = null
+  devBackends: Map<string, Backend> = new Map()
+  curFooterLength = 0
+  totalBackendsSpawned = 0
+
+  constructor(private jamsocket: Jamsocket, private opts: Options) {}
+
+  // returns a promise that resolves when the dev server is stopped
+  async start(): Promise<void> {
+    const { watch } = this.opts
+    this.currentImageId = await this.buildSessionBackend()
+
+    const server = this.startSpawnProxy()
+
+    const serverStopped = new Promise<void>(resolve => {
+      // listen for keyboard input
+      process.stdin.setRawMode(true)
+      process.stdin.resume()
+      process.stdin.setEncoding('utf8')
+      process.stdin.on('data', async (key: string) => {
+        // ctrl-c
+        if (key === '\u0003') {
+          server.close(async () => {
+            this.clearFooter()
+            console.log('Spawn proxy server stopped')
+
+            const curBackends = [...this.devBackends.values()].map(backend => backend.spawnResult.name)
+            if (curBackends.length > 0) {
+              console.log('Terminating development backends...')
+              await this.terminateBackends(curBackends)
+              this.clearFooter()
+            }
+            resolve()
+          })
+        }
+        if (key === 'b') {
+          this.rebuild()
+        }
+        if (key === 't') {
+          const backendNames = [...this.devBackends.values()].map(b => b.spawnResult.name)
+          if (backendNames.length > 0) {
+            this.updateFooterAndLog(['', 'Terminating development backends...'])
+            await this.terminateBackends(backendNames)
+          } else {
+            this.updateFooterAndLog(['', 'No development backends to terminate'])
+          }
+        }
+      })
+    })
+
+    if (watch) {
+      this.updateFooterAndLog([`Watching ${watch.join(', ')} for changes...`, ''])
+      const watchPaths = watch.map(w => path.resolve(process.cwd(), w))
+      chokidar.watch(watchPaths).on('change', this.rebuild.bind(this))
+    }
+
+    await serverStopped
+  }
+
+  async buildSessionBackend(): Promise<string> {
+    const { dockerfile, service } = this.opts
+    this.clearFooter()
+    const imageId = buildImage(dockerfile)
+    await this.jamsocket.push(service, imageId)
+    this.updateFooterAndLog(['', `Built and pushed image to ${service} service on the Jamsocket registry. ImageID: ${imageId}`])
+    return imageId
+  }
+
+  async rebuild(): Promise<void> {
+    this.currentImageId = await this.buildSessionBackend()
+
+    const outdatedBackends = [...this.devBackends.values()].filter(backend => backend.imageId !== this.currentImageId).map(backend => backend.spawnResult.name)
+    if (outdatedBackends.length > 0) {
+      this.updateFooterAndLog(['', 'Terminating outdated backends...'])
+      await this.terminateBackends(outdatedBackends)
+    }
+  }
+
+  async terminateBackends(backends: string[]): Promise<void> {
+    const terminationPromises = backends.map(name => this.jamsocket.terminate(name))
+    this.updateFooterAndLog([`Terminating ${backends.length} backend(s): ${backends.map(name => name).join(', ')}`])
+    await Promise.all(terminationPromises)
+    for (const name of backends) {
+      this.devBackends.delete(name)
+    }
+  }
+
+  getFooter(): string[] {
+    let footer = ['']
+    if (this.devBackends.size > 0) {
+      CliUx.ux.table<Backend>([...this.devBackends.values()], {
+        name: {
+          header: 'Name',
+          get: backend => chalk[backend.color](backend.spawnResult.name),
+        },
+        status: {
+          header: 'Status',
+          get: backend => chalk[backend.color](backend.lastStatus ?? '-'),
+        },
+        spawned: {
+          header: 'Spawn time',
+          get: backend => chalk[backend.color](`${formatDistanceToNow(new Date(backend.spawnTime))} ago`),
+        },
+        image: {
+          header: 'Image ID',
+          get: backend => chalk[backend.color](backend.imageId.slice(0, 7)),
+        },
+        lock: {
+          header: 'Lock',
+          get: backend => chalk[backend.color](backend.lock ?? '-'),
+        },
+      }, {
+        printLine: line => footer.push(line),
+      })
+    } else {
+      footer.push(chalk.bold` No running backends`)
+    }
+    footer.push(
+      '',
+      chalk.bold.italic` ${chalk.underline`[b]`} Build ${chalk.underline`[t]`} Terminate backends ${chalk.underline`[ctrl-c]`} Stop`,
+      '',
+    )
+
+    // draw a box around the footer
+
+    const padding = 2
+    // eslint-disable-next-line unicorn/no-array-reduce
+    const boxWidth = footer.reduce((max, line) => Math.max(max, stringLength(line)), 0) + (padding * 2) + 2
+    footer = footer.map(line => {
+      line = `\u2016${' '.repeat(padding)}${line}`
+      const endPadding = boxWidth - stringLength(line) - 1
+      return `${line}${' '.repeat(endPadding)}\u2016`
+    })
+
+    footer.unshift(chalk.bold(`\u2554${'='.repeat(boxWidth - 2)}\u2557`))
+    footer.push(chalk.bold(`\u255A${'='.repeat(boxWidth - 2)}\u255D`))
+
+    return footer
+  }
+
+  clearFooter(): void {
+    for (let i = 0; i < this.curFooterLength; i++) {
+      process.stdout.write('\r\u001B[1A') // move cursor up by one line and to beginning of line
+      process.stdout.write('\u001B[2K') // clear line
+    }
+    this.curFooterLength = 0
+  }
+
+  updateFooterAndLog(logLines: string[] = []): void {
+    this.clearFooter()
+
+    for (const logLine of logLines) {
+      console.log(logLine)
+    }
+
+    const footer = this.getFooter()
+    this.curFooterLength = footer.length
+    for (const line of footer) {
+      console.log(line)
+    }
+  }
+
+  async streamStatusAndLogs(backendName: string): Promise<void> {
+    const backend = this.devBackends.get(backendName)
+    if (!backend) throw new Error(`Backend ${backendName} not found in devBackends when attempting to stream status and logs`)
+
+    backend.isStreaming = true
+
+    // TODO: come up with a way to cancel these streams
+    const statusStream = this.jamsocket.streamStatus(backendName, status => {
+      const curStatus = status.state
+      backend.lastStatus = curStatus
+      this.updateFooterAndLog([chalk[backend.color](`[${backendName}] status: ${curStatus}`)])
+      if (!['Loading', 'Starting', 'Ready'].includes(curStatus)) {
+        this.devBackends.delete(backendName)
+      }
+    })
+    const logsStream = this.jamsocket.streamLogs(backendName, log => {
+      this.updateFooterAndLog([chalk[backend.color](`[${backendName}] ${log}`)])
+    })
+
+    await Promise.all([statusStream, logsStream])
+
+    this.updateFooterAndLog([chalk[backend.color](`[${backendName}] streams ended`)])
+    backend.isStreaming = false
+  }
+
+  startSpawnProxy(): http.Server {
+    const { service, account } = this.opts
+    const server = http.createServer(async (req, res) => {
+      // The only route this server implements is POST /user/{ACCOUNT}/service/{SERVICE}/spawn
+      const match = /^\/user\/([^/]+)\/service\/([^/]+)\/spawn/.exec(req.url ?? '')
+      if (req.method !== 'POST' || match === null) {
+        res.writeHead(404)
+        res.end()
+        return
+      }
+
+      const reqAccount = match[1]
+      const reqService = match[2]
+
+      if (service !== reqService) {
+        // TODO: make this a warning
+        this.updateFooterAndLog([`Request for service ${reqService} does not match service in config (${service}). Blocking spawn.`])
+        res.writeHead(401)
+        res.end()
+        return
+      }
+
+      if (account !== reqAccount) {
+        // TODO: make this a warning
+        this.updateFooterAndLog(['Request for account does not match logged-in account. Blocking spawn.'])
+        res.writeHead(401)
+        res.end()
+        return
+      }
+
+      /*
+        * TODO: The service really should be a development service, not a production one,
+        *       otherwise these pushes could break the production service.
+        *       Maybe use a special "development" tag for these?
+        */
+
+      const text = await readBody(req)
+      let body: Record<string, any> = {}
+      try {
+        body = JSON.parse(text)
+      } catch {}
+
+      const result = await this.spawnBackend(body)
+      if (result instanceof Error) {
+        res.writeHead(400)
+        res.end(result.toString())
+        return
+      }
+
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify(result))
+    })
+
+    server.listen(8080, () => {
+      this.updateFooterAndLog(['', 'Spawn proxy server running on http://localhost:8080', ''])
+    })
+
+    return server
+  }
+
+  async spawnBackend(body: SpawnRequestBody): Promise<SpawnResult | Error> {
+    const { service } = this.opts
+    const imageId = this.currentImageId
+
+    if (!imageId) {
+      throw new Error('spawnBackend called before currentImageId was set. This is a bug.')
+    }
+
+    const result = await this.jamsocket.spawn(
+      service,
+      body.env,
+      body.grace_period_seconds,
+      body.port,
+      body.tag,
+      body.require_bearer_token,
+      body.lock,
+    )
+
+    if (this.devBackends.has(result.name)) {
+      if (result.spawned) {
+        throw new Error(`Spawned backend ${result.name} already exists in devBackends but "spawned=true" in spawn response. Some bug has occurred.`)
+      }
+      const backend = this.devBackends.get(result.name)!
+      if (backend.imageId !== imageId) {
+        // TODO: make this a warning
+        this.updateFooterAndLog(['Spawn with lock returned a running backend with an outdated version of the session backend code. Blocking spawn.'])
+        return new Error('dev-server spawn proxy: Spawn with lock returned a running backend with an outdated version of the session backend code. Blocking spawn.')
+      }
+    } else if (result.spawned) {
+      const color = BACKEND_LOG_COLORS[this.totalBackendsSpawned % BACKEND_LOG_COLORS.length]
+      this.totalBackendsSpawned += 1
+      this.devBackends.set(result.name, {
+        spawnResult: result,
+        imageId: imageId,
+        spawnTime: Date.now(),
+        lastStatus: null,
+        lock: body.lock ?? null,
+        isStreaming: false,
+        color,
+      })
+      this.updateFooterAndLog(['', `Spawned backend: ${result.name}`])
+    } else {
+      // TODO: make this a warning
+      this.updateFooterAndLog(['Spawn with lock returned a running backend that was not originally spawned by this dev server. This may be dangerous. Blocking spawn.'])
+      return new Error('dev-server spawn proxy: Spawn with lock returned a running backend that was not originally spawned by this dev server. This may be dangerous. Blocking spawn.')
+    }
+
+    const backend = this.devBackends.get(result.name)!
+    if (!backend.isStreaming) {
+      this.updateFooterAndLog([`Streaming status and logs for ${result.name}...`, ''])
+      this.streamStatusAndLogs(result.name)
+    }
+
+    if (result.spawned) {
+      this.updateFooterAndLog()
+    }
+
+    return result
+  }
+}
+
+async function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = ''
+    req.on('data', (chunk: string) => {
+      body += chunk
+    })
+    req.on('end', () => {
+      resolve(body)
+    })
+    req.on('error', err => {
+      reject(err)
+    })
+  })
+}

--- a/src/dev-server/index.ts
+++ b/src/dev-server/index.ts
@@ -9,6 +9,8 @@ import { Jamsocket } from '../jamsocket'
 import { buildImage } from '../docker'
 import { SpawnResult, SpawnRequestBody } from '../api'
 
+const CTRL_C = '\u0003'
+
 type Color = 'cyan' | 'magenta' | 'yellow' | 'blue'
 
 type Backend = {
@@ -52,8 +54,7 @@ export default class DevServer {
       process.stdin.resume()
       process.stdin.setEncoding('utf8')
       process.stdin.on('data', async (key: string) => {
-        // ctrl-c
-        if (key === '\u0003') resolve()
+        if (key === CTRL_C) resolve()
         if (key === 'b') await this.rebuild()
         if (key === 't') await this.terminateAllDevbackends()
       })
@@ -223,7 +224,7 @@ export default class DevServer {
       logsStream.close()
     }
 
-    await Promise.all([statusStream.onClose, logsStream.onClose])
+    await Promise.all([statusStream.closed, logsStream.closed])
 
     this.updateFooterAndLog([chalk[backend.color](`[${backendName}] streams ended`)])
     backend.isStreaming = false

--- a/src/jamsocket.ts
+++ b/src/jamsocket.ts
@@ -2,6 +2,7 @@ import { JamsocketApi, BackendInfoResult, RunningBackendsResult, SpawnRequestBod
 import type { ServiceCreateResult, ServiceListResult, ServiceInfoResult, ServiceDeleteResult } from './api'
 import { JamsocketConfig } from './jamsocket-config'
 import { tag as dockerTag, push as dockerPush } from './docker'
+import type { EventStreamReturn } from './request'
 
 export class Jamsocket {
   constructor(public config: JamsocketConfig | null, private api: JamsocketApi) {}
@@ -93,17 +94,17 @@ export class Jamsocket {
     return this.api.serviceList(config.getAccount(), config.getAccessToken())
   }
 
-  public streamLogs(backend: string, callback: (v: string) => void): Promise<void> {
+  public streamLogs(backend: string, callback: (v: string) => void): EventStreamReturn {
     const config = this.expectAuthorized()
     return this.api.streamLogs(backend, config.getAccessToken(), callback)
   }
 
-  public streamMetrics(backend: string, callback: (v: string) => void): Promise<void> {
+  public streamMetrics(backend: string, callback: (v: string) => void): EventStreamReturn {
     const config = this.expectAuthorized()
     return this.api.streamMetrics(backend, config.getAccessToken(), callback)
   }
 
-  public streamStatus(backend: string, callback: (v: StatusMessage) => void): Promise<void> {
+  public streamStatus(backend: string, callback: (v: StatusMessage) => void): EventStreamReturn {
     const config = this.expectAuthorized()
     return this.api.streamStatus(backend, config.getAccessToken(), callback)
   }

--- a/src/jamsocket.ts
+++ b/src/jamsocket.ts
@@ -4,7 +4,7 @@ import { JamsocketConfig } from './jamsocket-config'
 import { tag as dockerTag, push as dockerPush } from './docker'
 
 export class Jamsocket {
-  constructor(private config: JamsocketConfig | null, private api: JamsocketApi) {}
+  constructor(public config: JamsocketConfig | null, private api: JamsocketApi) {}
 
   public static fromEnvironment(): Jamsocket {
     const config = JamsocketConfig.fromSaved()

--- a/src/request.ts
+++ b/src/request.ts
@@ -16,7 +16,7 @@ type RequestReturn = {
 
 export type EventStreamReturn = {
   close: () => void;
-  onClose: Promise<void>
+  closed: Promise<void>
 }
 
 const version = require('../package.json').version
@@ -129,7 +129,7 @@ export function eventStream(
     if (response) response.destroy()
   }
 
-  const onClose = new Promise<void>((resolve, reject) => {
+  const closed = new Promise<void>((resolve, reject) => {
     const wrappedURL = new URL(url)
     const headers = {
       'User-Agent': userAgent,
@@ -175,7 +175,7 @@ export function eventStream(
     request.end()
   })
 
-  return { close, onClose }
+  return { close, closed }
 }
 
 function responseIntoError(res: http.IncomingMessage): Promise<void> {


### PR DESCRIPTION
This adds a dev command to the CLI. It's currently marked as experimental, but I feel that (1) it solves enough problems that people run into during development, and (2) it's a real pain to keep a separate `beta` version updated with changes to the main branch, that it's probably worth just slapping an "Experimental" on the dev command's description and releasing it as part of the `latest` release.

A good way to try out the new dev command is by walking through [this version of the NextJS tutorial](https://github.com/drifting-in-space/jamsocket-nextjs-tutorial/blob/dev-cli-version/README.md).

Note: you'll need to add a `jamsocket.config.js` file that looks like this:

```js
module.exports = {
  dockerfile: './Dockerfile.jamsocket',
  service: 'whiteboard-demo',
  watch: ['./src/session-backend'],
}
```

And you'll need to add `apiUrl: 'http://localhost:8080'` to the `init()` function call in `src/app/page.tsx`, so that it looks like this:

```ts
const spawnBackend = init({
  account: '[FILL ME IN]',
  service: 'whiteboard-demo',
  token: '', // you can leave this blank
  apiUrl: 'http://localhost:8080'
})
```