### PR TITLE
Remove deprecated type deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
         "@oclif/core": "1.9.0",
         "@oclif/plugin-help": "5.1.12",
         "@oclif/plugin-warn-if-update-available": "2.0.4",
-        "@types/chalk": "^2.2.0",
-        "@types/date-fns": "^2.6.0",
         "chalk": "^4",
         "chokidar": "^3.5.3",
         "date-fns": "^2.29.3",
@@ -1164,24 +1162,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
-    },
-    "node_modules/@types/chalk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
-      "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
-      "deprecated": "This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!",
-      "dependencies": {
-        "chalk": "*"
-      }
-    },
-    "node_modules/@types/date-fns": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@types/date-fns/-/date-fns-2.6.0.tgz",
-      "integrity": "sha512-9DSw2ZRzV0Tmpa6PHHJbMcZn79HHus+BBBohcOaDzkK/G3zMjDUDYjJIWBFLbkh+1+/IOS0A59BpQfdr37hASg==",
-      "deprecated": "This is a stub types definition for date-fns (https://github.com/date-fns/date-fns). date-fns provides its own type definitions, so you don't need @types/date-fns installed!",
-      "dependencies": {
-        "date-fns": "*"
-      }
     },
     "node_modules/@types/expect": {
       "version": "1.20.4",
@@ -9195,22 +9175,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
-    },
-    "@types/chalk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
-      "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
-      "requires": {
-        "chalk": "*"
-      }
-    },
-    "@types/date-fns": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@types/date-fns/-/date-fns-2.6.0.tgz",
-      "integrity": "sha512-9DSw2ZRzV0Tmpa6PHHJbMcZn79HHus+BBBohcOaDzkK/G3zMjDUDYjJIWBFLbkh+1+/IOS0A59BpQfdr37hASg==",
-      "requires": {
-        "date-fns": "*"
-      }
     },
     "@types/expect": {
       "version": "1.20.4",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "@oclif/core": "1.9.0",
     "@oclif/plugin-help": "5.1.12",
     "@oclif/plugin-warn-if-update-available": "2.0.4",
-    "@types/chalk": "^2.2.0",
-    "@types/date-fns": "^2.6.0",
     "chalk": "^4",
     "chokidar": "^3.5.3",
     "date-fns": "^2.29.3",


### PR DESCRIPTION
Removes these warnings:

<img width="1427" alt="image" src="https://github.com/drifting-in-space/jamsocket-cli/assets/46173/d9532e9f-7316-421a-b8e5-c9174c283283">
