### PR TITLE
[DIS-1325] [DIS-1323] handle docker errors, better dev cmd logs, terminate backends on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ EXAMPLES
   $ jamsocket dev
 ```
 
-_See code: [src/commands/dev.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.2/src/commands/dev.ts)_
+_See code: [src/commands/dev.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.3/src/commands/dev.ts)_
 
 ## `jamsocket help [COMMAND]`
 
@@ -185,7 +185,7 @@ EXAMPLES
   $ jamsocket login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.2/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.3/src/commands/login.ts)_
 
 ## `jamsocket logout`
 
@@ -202,7 +202,7 @@ EXAMPLES
   $ jamsocket logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.2/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.3/src/commands/logout.ts)_
 
 ## `jamsocket logs BACKEND`
 
@@ -249,7 +249,7 @@ EXAMPLES
   $ jamsocket push my-service my-image -t my-tag
 ```
 
-_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.2/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.3/src/commands/push.ts)_
 
 ## `jamsocket service create NAME`
 
@@ -341,7 +341,7 @@ EXAMPLES
   $ jamsocket spawn my-service -t latest
 ```
 
-_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.2/src/commands/spawn.ts)_
+_See code: [src/commands/spawn.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.3/src/commands/spawn.ts)_
 
 ## `jamsocket terminate BACKEND`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "scripts": {
     "build": "shx rm -rf lib && tsc -b",
-    "lint": "eslint . --ext .ts --config .eslintrc",
+    "lint": "eslint src --ext .ts --config .eslintrc",
     "postpack": "shx rm -f oclif.manifest.json",
     "posttest": "npm run lint",
     "prepare": "npm run build",

--- a/src/dev-server/index.ts
+++ b/src/dev-server/index.ts
@@ -44,6 +44,8 @@ export default class DevServer {
   // returns a promise that resolves when the dev server is stopped
   async start(): Promise<void> {
     const { watch } = this.opts
+
+    console.log('Starting dev server...')
     this.currentImageId = await this.buildSessionBackend()
 
     const server = this.startSpawnProxy()
@@ -88,10 +90,13 @@ export default class DevServer {
 
   async buildSessionBackend(): Promise<string> {
     const { dockerfile, service } = this.opts
+    this.updateFooterAndLog(['Building image...'])
     this.clearFooter()
     const imageId = buildImage(dockerfile)
+    this.updateFooterAndLog(['Image built.', 'Pushing image...'])
+    this.clearFooter()
     await this.jamsocket.push(service, imageId)
-    this.updateFooterAndLog(['', `Built and pushed image to ${service} service on the Jamsocket registry. ImageID: ${imageId}`])
+    this.updateFooterAndLog([`Image pushed to ${service} service on the Jamsocket registry. ImageID: ${imageId}`])
     return imageId
   }
 

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,31 +1,23 @@
-import { spawn, spawnSync } from 'child_process'
+import { SpawnSyncOptionsWithStringEncoding, SpawnSyncReturns, StdioOptions, spawn, spawnSync } from 'child_process'
 import { mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { JAMSOCKET_CONFIG_DIR } from './jamsocket-config'
 
 export function getImagePlatform(imageName: string): { os: string, arch: string } {
-  const getPlatform = spawnSync('docker', ['image', 'inspect', '--format', '{{.Os}} {{.Architecture}}', imageName])
-  if (getPlatform.status !== 0) {
-    const stderr = getPlatform.stderr.toString().trim()
-    throw new Error(`Encountered docker error:\n${stderr}`)
-  }
+  const getPlatform = spawnDockerSync(['image', 'inspect', '--format', '{{.Os}} {{.Architecture}}', imageName])
+  if (getPlatform.stdout === null) throw new Error('Docker exited without errors but unable to detect image platform.')
   const stdout = getPlatform.stdout.toString().trim()
   const [os, arch] = stdout.split(' ').map(s => s.trim())
   return { os, arch }
 }
 
 export function buildImage(dockerfilePath: string): string {
-  const buildProcess = spawnSync('docker', ['build', '--quiet', '--platform', 'linux/amd64', '-f', dockerfilePath, '.'], { encoding: 'utf-8' })
-  const exitCode = buildProcess.status
-  if (exitCode !== null && exitCode !== 0) {
-    throw new Error(`Process exited with a non-zero code: ${exitCode}`)
-  }
-
+  const buildProcess = spawnDockerSync(['build', '--quiet', '--platform', 'linux/amd64', '-f', dockerfilePath, '.'])
   // eslint-disable-next-line unicorn/better-regex
   const match = /sha256:([a-f0-9]+)/.exec(buildProcess.stdout)
   const imageId = match?.[1] || null
   if (imageId === null) {
-    throw new Error("Process exited with zero exit code but couldn't extract image id from output.")
+    throw new Error("Docker exited without errors but couldn't extract image id from output.")
   }
   return imageId
 }
@@ -46,6 +38,14 @@ export async function push(imageName: string, auth: string): Promise<void> {
 
   await new Promise<void>((resolve, reject) => {
     const pushProcess = spawn('docker', ['--config', dockerConfigDir, 'push', imageName], { stdio: 'inherit' })
+    pushProcess.on('error', err => {
+      if (err.message.includes('ENOENT')) {
+        reject(new Error('Docker command not found. Make sure Docker is installed and in your PATH.'))
+      } else {
+        reject(err)
+      }
+    })
+
     pushProcess.on('close', code => {
       if (code === 0) {
         resolve()
@@ -57,8 +57,28 @@ export async function push(imageName: string, auth: string): Promise<void> {
 }
 
 export function tag(existingImageName: string, newImageName: string): void {
-  const tagOutput = spawnSync('docker', ['tag', existingImageName, newImageName], { encoding: 'utf-8', stdio: 'inherit' })
-  if (tagOutput.status !== 0) {
-    throw new Error(tagOutput.error?.message ?? 'Error tagging image')
+  spawnDockerSync(['tag', existingImageName, newImageName], { stdio: 'inherit' })
+}
+
+function spawnDockerSync(args: string[], options?: { stdio?: StdioOptions }): SpawnSyncReturns<string> {
+  const opts: SpawnSyncOptionsWithStringEncoding = { encoding: 'utf-8', ...options }
+  const result = spawnSync('docker', args, opts)
+  const exitCode = result.status
+  if (
+    (exitCode !== null && exitCode !== 0) ||
+    result.error !== undefined
+  ) {
+    if (result.stderr?.includes('No such image')) {
+      throw new Error('Docker failed to find image. Make sure you have built the image and it\'s listed in the `docker images` command output before running this command.')
+    }
+    if (result.stderr?.includes('Cannot connect to the Docker daemon')) {
+      throw new Error('Docker failed to connect to the Docker daemon. Make sure Docker is running and you have permission to access it.')
+    }
+    if (result.error?.message.includes('ENOENT')) {
+      throw new Error('Docker command not found. Make sure Docker is installed and in your PATH.')
+    }
+
+    throw new Error(`Process "docker ${args.join(' ')}" exited with a non-zero code: ${exitCode} ${result.error} ${result.stderr}`)
   }
+  return result
 }


### PR DESCRIPTION
While developing with the dev CLI, we noticed a few things we wanted to fix:
1. When the dev CLI starts up, it builds the session backend image, but it doesn't output any logs re: to it, so it looks like the dev command is just hanging for a long time.
2. The dev command can sometimes error out, when this happens, backends that were spawned as part of development are left running. Let's catch those errors and make sure to clean up any running backends before exiting.
3. The dev CLI only works if Docker is installed, in the PATH, and is configured correctly. Let's catch some of the more common Docker-related issues and give better instructions in the user-facing error messages.