### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A CLI for the Jamsocket platform
 
 # Install
 
-We recommend you run the Jamsocket CLI without explicitly installing it using `npx jamsocket`. You may also install it locally within a project or globally using `npm install jamsocket` (and `npm install jamsocket -g`).
+We recommend you use `npx jamsocket` to run the Jamsocket CLI without explicitly installing it. You may also install it locally within a project using `npm install jamsocket`.
 
 # Authentication
 

--- a/README.md
+++ b/README.md
@@ -6,22 +6,13 @@ A CLI for the Jamsocket platform
 
 # Install
 
-You may run the Jamsocket CLI without explicitly installing it using `npx jamsocket`. However, this may lead to CLI-version-related issues as [NPX is not guaranteed to run the latest version](https://github.com/npm/cli/issues/4108) and will instead use whatever version was cached with the first usage.
-
-For this reason it is recommended that you first install the Jamsocket CLI either globally or in your project and _then_ use `npx jamsocket`. (When running `npx jamsocket` from your project, the locally-installed `jamsocket` will be used.) When installing the Jamsocket CLI globally, it is recommended you use a tool like [Node Version Manager](https://github.com/nvm-sh/nvm#installing-and-updating) to manage your NodeJS binaries. NVM makes sure these binaries are installed under your user so global npm installs do not require root privileges. Once NVM is set up, run `npm install jamsocket --global`.
-
-# Upgrading
-
-```sh
-npm install jamsocket@latest # to update the locally-installed Jamsocket
-npm install jamsocket@latest --global # to update the global installation of Jamsocket
-```
+We recommend you run the Jamsocket CLI without explicitly installing it using `npx jamsocket`. You may also install it locally within a project or globally using `npm install jamsocket` (and `npm install jamsocket -g`).
 
 # Authentication
 
-Run `jamsocket login`.
+Run `npx jamsocket login`.
 
-If you want to use the Jamsocket CLI from an automated environment (e.g. a CI/CD pipeline), you can authenticate with an access token by running `jamsocket login --token [ACCESS_TOKEN]`. You can manage and generate access tokens from the [Jamsocket Settings page](https://app.jamsocket.com/settings).
+If you want to use the Jamsocket CLI from an automated environment (e.g. a CI/CD pipeline), you can authenticate with an access token by running `npx jamsocket login --token [ACCESS_TOKEN]`. You can manage and generate access tokens from the [Jamsocket Settings page](https://app.jamsocket.com/settings).
 
 # Commands
 <!-- commands -->

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "version": "oclif readme && git add README.md"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=18.0.0"
   },
   "bugs": "https://github.com/drifting-in-space/jamsocket-cli/issues",
   "keywords": [

--- a/src/request.ts
+++ b/src/request.ts
@@ -40,8 +40,8 @@ export async function checkVersion(): Promise<void> {
     const latestVersion = JSON.parse(response.body)['dist-tags'].latest
     const isVersionOld = isVersionLessThan(version, latestVersion)
     if (isVersionOld) {
-      console.error(`    Your Jamsocket CLI version (${version}) is out of date. You can update to the latest version (${latestVersion}) with:`)
-      console.error('        npm install jamsocket@latest --global')
+      console.error(`    Your Jamsocket CLI version (${version}) is out of date. You may need to update to the latest version (${latestVersion}) with:`)
+      console.error('        npm install jamsocket@latest')
       console.error()
     }
   } catch {}


### PR DESCRIPTION
As of npm v9.6.5, [the bug has been fixed](https://github.com/npm/rfcs/issues/700#issuecomment-1594872380) where npx only used the package version that was _originally_ used when _first running_ `npx my-package` - even if a newer package version had been released or had even been specifically requested in a subsequent `npx my-package@latest` call.

That means we can clean up the installation instructions in the README and just recommend people use `npx jamsocket` instead of `npx jamsocket@latest` now.