### PR TITLE
dev cli uses plane2 and runs entirely locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "chalk": "^4",
         "chokidar": "^3.5.3",
         "date-fns": "^2.29.3",
+        "eventsource": "^2.0.2",
         "inquirer": "^8.2.5",
         "is-wsl": "^2.2.0",
         "string-length": "4.0.2"
@@ -23,6 +24,7 @@
         "jamsocket": "bin/run"
       },
       "devDependencies": {
+        "@types/eventsource": "^1.1.15",
         "@types/inquirer": "^8.2.4",
         "@types/node": "^16.9.4",
         "eslint": "^7.32.0",
@@ -36,7 +38,7 @@
         "typescript": "^4.4.3"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1161,6 +1163,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "node_modules/@types/eventsource": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
+      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
       "dev": true
     },
     "node_modules/@types/expect": {
@@ -3133,6 +3141,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/execa": {
@@ -9176,6 +9192,12 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/eventsource": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
+      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
+      "dev": true
+    },
     "@types/expect": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
@@ -10617,6 +10639,11 @@
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
+    },
+    "eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
     },
     "execa": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
     "chalk": "^4",
     "chokidar": "^3.5.3",
     "date-fns": "^2.29.3",
+    "eventsource": "^2.0.2",
     "inquirer": "^8.2.5",
     "is-wsl": "^2.2.0",
     "string-length": "4.0.2"
   },
   "devDependencies": {
+    "@types/eventsource": "^1.1.15",
     "@types/inquirer": "^8.2.4",
     "@types/node": "^16.9.4",
     "eslint": "^7.32.0",

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,35 +1,25 @@
 import { existsSync } from 'fs'
 import path from 'path'
 import { Command } from '@oclif/core'
-import { Jamsocket } from '../jamsocket'
-import DevServer from '../dev-server'
+import { createDevServer } from '../dev-server'
 
 export default class Dev extends Command {
   static description = '(Experimental) Starts a jamsocket dev server.'
   static examples = ['<%= config.bin %> <%= command.id %>']
 
   public async run(): Promise<void> {
-    const jamsocket = Jamsocket.fromEnvironment()
-    const { dockerfile, service, watch } = loadProjectConfig()
-    const account = jamsocket.config?.getAccount()
-
-    if (!account) {
-      throw new Error('Must be logged in to use this command. Log in with jamsocket login')
-    }
-
-    const devServer = new DevServer(jamsocket, { dockerfile, service, watch, account })
-    await devServer.start()
+    const { dockerfile, watch } = loadProjectConfig()
+    await createDevServer({ dockerfile, watch })
   }
 }
 
 const PROJECT_CONFIG_PATH = path.resolve(process.cwd(), 'jamsocket.config.js')
 
-function loadProjectConfig(): { dockerfile: string, service: string, watch?: string[] } {
+function loadProjectConfig(): { dockerfile: string, watch?: string[] } {
   if (!existsSync(PROJECT_CONFIG_PATH)) throw new Error('No jamsocket.config.js found in current directory')
-  const { dockerfile, service, watch } = require(PROJECT_CONFIG_PATH)
+  const { dockerfile, watch } = require(PROJECT_CONFIG_PATH)
   return {
     dockerfile: path.resolve(process.cwd(), dockerfile),
-    service,
     watch: typeof watch === 'string' ? [watch] : watch,
   }
 }

--- a/src/dev-server/logger.ts
+++ b/src/dev-server/logger.ts
@@ -1,0 +1,66 @@
+import chalk from 'chalk'
+import stringLength from 'string-length'
+
+export class Logger {
+  curFooterLength = 0
+  displayFooter = false
+
+  constructor(private _getFooter: () => string[]) {}
+
+  footerOff(): void {
+    this.displayFooter = false
+    this.clearFooter()
+  }
+
+  footerOn(): void {
+    this.displayFooter = true
+    this.refreshFooter()
+  }
+
+  log(logLines: string[] = []): void {
+    this.clearFooter()
+
+    for (const logLine of logLines) {
+      console.log(logLine)
+    }
+
+    if (this.displayFooter) {
+      const footer = this.getFooter()
+      this.curFooterLength = footer.length
+      for (const line of footer) {
+        console.log(line)
+      }
+    }
+  }
+
+  refreshFooter(): void {
+    this.log()
+  }
+
+  getFooter(): string[] {
+    let footer = this._getFooter()
+
+    // draw a box around the footer
+    const padding = 2
+    // eslint-disable-next-line unicorn/no-array-reduce
+    const boxWidth = footer.reduce((max, line) => Math.max(max, stringLength(line)), 0) + (padding * 2) + 2
+    footer = footer.map(line => {
+      line = `\u2016${' '.repeat(padding)}${line}`
+      const endPadding = boxWidth - stringLength(line) - 1
+      return `${line}${' '.repeat(endPadding)}\u2016`
+    })
+
+    footer.unshift(chalk.bold(`\u2554${'='.repeat(boxWidth - 2)}\u2557`))
+    footer.push(chalk.bold(`\u255A${'='.repeat(boxWidth - 2)}\u255D`))
+
+    return footer
+  }
+
+  clearFooter(): void {
+    for (let i = 0; i < this.curFooterLength; i++) {
+      process.stdout.write('\r\u001B[1A') // move cursor up by one line and to beginning of line
+      process.stdout.write('\u001B[2K') // clear line
+    }
+    this.curFooterLength = 0
+  }
+}

--- a/src/dev-server/logger.ts
+++ b/src/dev-server/logger.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 import stringLength from 'string-length'
+import { termwidth } from './util'
 
 export class Logger {
   curFooterLength = 0
@@ -40,18 +41,23 @@ export class Logger {
   getFooter(): string[] {
     let footer = this._getFooter()
 
+    const terminalWidth = termwidth()
+
     // draw a box around the footer
     const padding = 2
     // eslint-disable-next-line unicorn/no-array-reduce
     const boxWidth = footer.reduce((max, line) => Math.max(max, stringLength(line)), 0) + (padding * 2) + 2
-    footer = footer.map(line => {
-      line = `\u2016${' '.repeat(padding)}${line}`
-      const endPadding = boxWidth - stringLength(line) - 1
-      return `${line}${' '.repeat(endPadding)}\u2016`
-    })
+    if (boxWidth <= terminalWidth) {
+      footer = footer.map(line => {
+        line = `\u2016${' '.repeat(padding)}${line}`
+        const endPadding = boxWidth - stringLength(line) - 1
+        return `${line}${' '.repeat(endPadding)}\u2016`
+      })
+    }
 
-    footer.unshift(chalk.bold(`\u2554${'='.repeat(boxWidth - 2)}\u2557`))
-    footer.push(chalk.bold(`\u255A${'='.repeat(boxWidth - 2)}\u255D`))
+    const repeatCount = boxWidth <= terminalWidth ? boxWidth - 2 : terminalWidth - 2
+    footer.unshift(chalk.bold(`\u2554${'='.repeat(repeatCount)}\u2557`))
+    footer.push(chalk.bold(`\u255A${'='.repeat(repeatCount)}\u255D`))
 
     return footer
   }

--- a/src/dev-server/plane.ts
+++ b/src/dev-server/plane.ts
@@ -1,0 +1,242 @@
+import { spawn, type ChildProcessWithoutNullStreams, spawnSync } from 'child_process'
+import readline from 'readline'
+import chalk from 'chalk'
+import EventSource from 'eventsource'
+import { SpawnResult, HTTPError } from '../api'
+import type { Logger } from './logger'
+
+export type PlaneConnectResponse = {
+  backend_id: string
+  spawned: boolean
+  token: string
+  url: string
+  secret_token: string
+  status_url: string
+  status: string
+}
+export type PlaneStatusMessage = {
+  status: string,
+  time: number,
+}
+export type StatusV1 = {
+  state: string,
+  time: string,
+  backend: string,
+}
+export type StreamHandle = {
+  closed: Promise<void>
+  close: () => void
+}
+
+const PLANE_IMAGE = 'plane/quickstart:sha-90eefde'
+
+// NOTE: this class works with a Plane2 interface, but its own interface is meant to be compatible with Jamsocket V1
+export class LocalPlane {
+  private _readyPromise: Promise<void> | null = null
+  constructor(
+    private url: string,
+    private process: ChildProcessWithoutNullStreams,
+    private containerName: string,
+    private logger: Logger,
+  ) {
+    readline.createInterface({ input: this.process.stderr }).on('line', line => {
+      this.logger.log([chalk.red(`[plane stderr] ${line}`)])
+    })
+    readline.createInterface({ input: this.process.stdout }).on('line', line => {
+      this.logger.log([`[plane stdout] ${line}`])
+    })
+    this.process.on('exit', () => {
+      this.logger.log([`Plane process exited with code: ${this.process.exitCode ?? 'unknown'}`])
+    })
+  }
+
+  kill(): void {
+    spawnSync('docker', ['kill', this.containerName])
+  }
+
+  ready(): Promise<void> {
+    if (this._readyPromise) return this._readyPromise
+    this._readyPromise = new Promise(resolve => {
+      // wait for the "[SERVICE] entered RUNNING state" lines to appear in the logs
+      const planeServices = new Set(['plane-controller', 'plane-drone', 'plane-proxy', 'postgres'])
+      const rl = readline.createInterface({ input: this.process.stdout }).on('line', line => {
+        const match = /([a-z-]+) entered RUNNING state/.exec(line)
+        if (match && planeServices.has(match[1])) {
+          planeServices.delete(match[1])
+          if (planeServices.size === 0) {
+            rl.close()
+            resolve()
+          }
+        }
+      })
+    })
+    return this._readyPromise
+  }
+
+  streamLogs(backend: string, callback: (logLine: string) => void): StreamHandle {
+    const containerName = `plane-${backend}`
+    const logsProcess = spawn('docker', ['logs', containerName, '-f'])
+    const stdout = readline.createInterface({ input: logsProcess.stdout }).on('line', callback)
+    const stderr = readline.createInterface({ input: logsProcess.stderr }).on('line', callback)
+    const close = () => {
+      stdout.close()
+      stderr.close()
+      logsProcess.kill()
+    }
+    const closed = new Promise<void>((resolve, reject) => {
+      logsProcess.on('error', err => {
+        if (err.message.includes('ENOENT')) {
+          reject(new Error('Docker command not found. Make sure Docker is installed and in your PATH.'))
+        } else {
+          reject(err)
+        }
+      })
+
+      logsProcess.on('close', resolve)
+    })
+
+    return { close, closed }
+  }
+
+  async terminate(backend: string): Promise<void | HTTPError> {
+    // TODO: should we do a soft-terminate here?
+    const terminateUrl = `${this.url}/ctrl/b/${backend}/hard-terminate`
+    const response = await fetch(terminateUrl, { method: 'POST' })
+    const body = await response.text()
+    if (response.status !== 200) {
+      throw new HTTPError(response.status, response.statusText, `Failed to terminate backend: ${response.status} ${response.statusText} - ${body}`)
+    }
+  }
+
+  streamStatus(backend: string, callback: (statusMessage: StatusV1) => void): StreamHandle {
+    const statusUrl = `${this.url}/pub/b/${backend}/status-stream`
+    const es = new EventSource(statusUrl)
+    es.addEventListener('message', (e: MessageEvent) => {
+      const val = JSON.parse(e.data) as PlaneStatusMessage
+      const v1Status = translateStatusToV1(val.status)
+      if (v1Status === null) return
+      callback({
+        state: v1Status,
+        time: (new Date(val.time)).toISOString(),
+        backend,
+      })
+    })
+    let resolveClosed: () => void
+    const closed = new Promise<void>(resolve => {
+      resolveClosed = resolve
+    })
+
+    function close() {
+      es.close()
+      resolveClosed()
+    }
+
+    es.addEventListener('error', close)
+
+    return { closed, close }
+  }
+
+  async spawn(
+    image: string,
+    env?: Record<string, string>,
+    gracePeriodSeconds?: number,
+    lock?: string,
+  ): Promise<SpawnResult | HTTPError> {
+    const spawnUrl = `${this.url}/ctrl/connect`
+    const spawnBody = {
+      key: lock ? {
+        name: lock,
+        tag: image,
+      } : undefined,
+      spawn_config: {
+        executable: { image, env },
+        max_idle_seconds: gracePeriodSeconds,
+      },
+    }
+    const response = await fetch(spawnUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(spawnBody),
+    })
+
+    const body = await response.text()
+
+    if (response.status !== 200) {
+      return new HTTPError(response.status, response.statusText, `Failed to spawn backend: ${response.status} ${response.statusText} - ${body}`)
+    }
+
+    const bodyJson = JSON.parse(body) as PlaneConnectResponse
+    return {
+      name: bodyJson.backend_id,
+      spawned: bodyJson.spawned,
+      url: bodyJson.url,
+      status_url: bodyJson.status_url,
+      ready_url: '',
+      status: bodyJson.status,
+    }
+  }
+}
+
+// Plane2 statuses: Scheduled, Loading, Starting, Waiting, Ready, Terminating, Terminated
+// if this returns null, then ignore the status
+function translateStatusToV1(plane2Status: string): string | null {
+  switch (plane2Status) {
+  case 'Scheduled':
+  case 'Waiting':
+  case 'Terminating':
+    return null
+  default:
+    return plane2Status
+  }
+}
+
+export function isV1StatusAlive(v1Status: string): boolean {
+  return ['Loading', 'Starting', 'Ready'].includes(v1Status)
+}
+
+export function runPlane(): { url: string, process: ChildProcessWithoutNullStreams, containerName: string } {
+  const containerName = `plane-quickstart-${Math.floor(Math.random() * 1_000_000)}`
+  // NOTE: for now, plane quickstart MUST be run port 8080
+  // and the cluster must be served on 9090 as these are
+  // hardcoded in the quickstart image
+  const process = spawn('docker', [
+    'run',
+    '-p',
+    '8080:8080',
+    '-p',
+    '9090:9090',
+    '--name',
+    containerName,
+    '-v',
+    '/var/run/docker.sock:/var/run/docker.sock',
+    PLANE_IMAGE,
+  ])
+
+  const url = 'http://localhost:8080'
+
+  return { url, process, containerName }
+}
+
+export function ensurePlaneImage(): Promise<void> {
+  const result = spawnSync('docker', ['image', 'inspect', PLANE_IMAGE])
+  if (result.status === 0) return Promise.resolve()
+  return new Promise((resolve, reject) => {
+    console.log('Downloading plane/quickstart image...')
+    const pullProcess = spawn('docker', ['pull', PLANE_IMAGE])
+    pullProcess.stdout.on('data', data => {
+      process.stdout.write(data)
+    })
+    pullProcess.stderr.on('data', data => {
+      process.stdout.write(data)
+    })
+    pullProcess.on('exit', () => {
+      if (pullProcess.exitCode === 0) {
+        resolve()
+      } else {
+        reject()
+      }
+    })
+  })
+}

--- a/src/dev-server/util.ts
+++ b/src/dev-server/util.ts
@@ -1,0 +1,29 @@
+import http from 'http'
+
+export type Color = 'cyan' | 'magenta' | 'yellow' | 'blue'
+const BACKEND_LOG_COLORS: Color[] = ['cyan', 'magenta', 'yellow', 'blue']
+
+export function createColorGetter(): () => Color {
+  let curColor = 0
+  // eslint-disable-next-line func-names
+  return function getColor(): Color {
+    const color = BACKEND_LOG_COLORS[curColor]
+    curColor = (curColor + 1) % BACKEND_LOG_COLORS.length
+    return color
+  }
+}
+
+export async function readRequestBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = ''
+    req.on('data', (chunk: string) => {
+      body += chunk
+    })
+    req.on('end', () => {
+      resolve(body)
+    })
+    req.on('error', (err: any) => {
+      reject(err)
+    })
+  })
+}

--- a/src/dev-server/util.ts
+++ b/src/dev-server/util.ts
@@ -27,3 +27,21 @@ export async function readRequestBody(req: http.IncomingMessage): Promise<string
     })
   })
 }
+
+// lifted from https://github.com/oclif/core
+export function termwidth(): number {
+  if (!process.stdout.isTTY) {
+    return 80
+  }
+
+  const width = process.stdout.getWindowSize()[0]
+  if (width < 1) {
+    return 80
+  }
+
+  if (width < 40) {
+    return 40
+  }
+
+  return width
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -139,10 +139,16 @@ export function eventStream(
       Accept: 'text/event-stream',
     }
 
-    request = https.request({
+    let protocol = https
+    if (wrappedURL.protocol === 'http:') {
+      protocol = http as any
+    }
+
+    request = protocol.request({
       ...options,
       hostname: wrappedURL.hostname,
       path: wrappedURL.pathname,
+      port: wrappedURL.port,
       headers: headers,
     }, res => {
       response = res

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "target": "es2019",
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
The main thing that's changed here is the dev CLI now runs Plane locally. It still exposes the current Jamsocket spawn, status, and status/stream interfaces however.

So much has been rewritten/restructured/refactored, that it's probably best to just ignore the diffs and review the new version of the code.

------

Some instructions for pulling this down and trying it out:

In `jamsocket-cli`, check out this branch (`taylor/dis-1535-dev-cli-plane2`), then install and build the CLI:

```
npm install
npm run build
```

In `jamsocket-nextjs-tutorial`, check out the `completed` branch, then update the following files in the nextjs tutorial codebase:
* `package.json`, update `jamsocket-javascript` to version `0.1.2`.
* `src/app/page.tsx`, change `apiUrl` to `http://localhost:8888`

Then run the nextjs dev command like normal:

```
npm install
npm run dev
```

Finally, run the new Jamsocket CLI from the `jamsocket-nextjs-tutorial` directory:

```
../jamsocket-cli/bin/run dev
```