### PR TITLE
v0.8.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ EXAMPLES
   $ jamsocket dev
 ```
 
-_See code: [src/commands/dev.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.6/src/commands/dev.ts)_
+_See code: [src/commands/dev.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.8.0-beta/src/commands/dev.ts)_
 
 ## `jamsocket help [COMMAND]`
 
@@ -198,7 +198,7 @@ EXAMPLES
   $ jamsocket login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.6/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.8.0-beta/src/commands/login.ts)_
 
 ## `jamsocket logout`
 
@@ -215,7 +215,7 @@ EXAMPLES
   $ jamsocket logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.6/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.8.0-beta/src/commands/logout.ts)_
 
 ## `jamsocket logs BACKEND`
 
@@ -262,7 +262,7 @@ EXAMPLES
   $ jamsocket push my-service my-image -t my-tag
 ```
 
-_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.7.6/src/commands/push.ts)_
+_See code: [src/commands/push.ts](https://github.com/drifting-in-space/jamsocket-cli/blob/v0.8.0-beta/src/commands/push.ts)_
 
 ## `jamsocket service create NAME`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.7.6",
+  "version": "0.8.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.7.6",
+      "version": "0.8.0-beta",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.7.6",
+  "version": "0.8.0-beta",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {


### PR DESCRIPTION
This creates a version 0.8.0-beta for testing out the new CLI dev command changes. This has been published to `jamsocket@next` (but `jamsocket@latest` remains unchanged).