### PR TITLE
support Jamsocket spawn API's `service_environment` field

### DIFF
--- a/examples/multiplayer-editor/package.json
+++ b/examples/multiplayer-editor/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@jamsocket/server": "0.2.2",
-    "@jamsocket/socketio": "0.2.2",
+    "@jamsocket/server": "0.2.3",
+    "@jamsocket/socketio": "0.2.3",
     "@types/node": "20.1.4",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,8 @@
     "examples/multiplayer-editor": {
       "version": "0.1.0",
       "dependencies": {
-        "@jamsocket/server": "0.2.2",
-        "@jamsocket/socketio": "0.2.2",
+        "@jamsocket/server": "0.2.3",
+        "@jamsocket/socketio": "0.2.3",
         "@types/node": "20.1.4",
         "@types/react": "18.2.6",
         "@types/react-dom": "18.2.4",
@@ -5927,15 +5927,15 @@
     },
     "packages/typescript/client": {
       "name": "@jamsocket/client",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT"
     },
     "packages/typescript/react": {
       "name": "@jamsocket/react",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/client": "0.2.2"
+        "@jamsocket/client": "0.2.3"
       },
       "devDependencies": {
         "@types/react": "^18.2.59"
@@ -5946,7 +5946,7 @@
     },
     "packages/typescript/server": {
       "name": "@jamsocket/server",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0"
@@ -5954,10 +5954,10 @@
     },
     "packages/typescript/socketio": {
       "name": "@jamsocket/socketio",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/react": "0.2.2",
+        "@jamsocket/react": "0.2.3",
         "socket.io-client": "^4.7.4"
       },
       "devDependencies": {

--- a/packages/typescript/client/package.json
+++ b/packages/typescript/client/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "JavaScript/TypeScript libraries for interacting with session backends and the Jamsocket platform.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/packages/typescript/react/package.json
+++ b/packages/typescript/react/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "React hooks for interacting with session backends and the Jamsocket platform.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/client": "0.2.2"
+    "@jamsocket/client": "0.2.3"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"

--- a/packages/typescript/server/README.md
+++ b/packages/typescript/server/README.md
@@ -128,6 +128,7 @@ type JamsocketSpawnOptions = {
   lock?: string
   env?: Record<string, string>
   gracePeriodSeconds?: number
+  serviceEnvironment?: string
 }
 
 type SpawnResult = {

--- a/packages/typescript/server/package.json
+++ b/packages/typescript/server/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "JavaScript/TypeScript libraries for spawning session backends server-side.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/packages/typescript/server/src/main.ts
+++ b/packages/typescript/server/src/main.ts
@@ -27,12 +27,14 @@ export type JamsocketSpawnOptions = {
   lock?: string
   env?: Record<string, string>
   gracePeriodSeconds?: number
+  serviceEnvironment?: string
 }
 
 type JamsocketApiSpawnBody = {
   lock?: string
   env?: Record<string, string>
   grace_period_seconds?: number
+  service_environment?: string
 }
 
 const JAMSOCKET_DEV_PORT = 8080
@@ -81,6 +83,7 @@ export function init(opts: JamsocketInitOptions): JamsocketInstance {
     if (spawnOpts.lock) reqBody.lock = spawnOpts.lock
     if (spawnOpts.env) reqBody.env = spawnOpts.env
     if (spawnOpts.gracePeriodSeconds) reqBody.grace_period_seconds = spawnOpts.gracePeriodSeconds
+    if (spawnOpts.serviceEnvironment) reqBody.service_environment = spawnOpts.serviceEnvironment
 
     const response = await fetch(`${apiUrl}/user/${account}/service/${service}/spawn`, {
       method: 'POST',

--- a/packages/typescript/socketio/package.json
+++ b/packages/typescript/socketio/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "React hooks for interacting with socket.io servers in Jamsocket session backends.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/react": "0.2.2",
+    "@jamsocket/react": "0.2.3",
     "socket.io-client": "^4.7.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
This makes it so that folks who use [Jamsocket's Service Environments](https://docs.jamsocket.com/concepts/environments) can actually spawn to a specific service environment with `@jamsocket/server`'s `spawn()` function.