### PR TITLE
misc jamsocket cli updates

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -29,7 +29,7 @@ If you want to use the Jamsocket CLI from an automated environment (e.g. a CI/CD
 * [`jamsocket login`](#jamsocket-login)
 * [`jamsocket logout`](#jamsocket-logout)
 * [`jamsocket logs BACKEND`](#jamsocket-logs-backend)
-* [`jamsocket push SERVICE IMAGE`](#jamsocket-push-service-image)
+* [`jamsocket push SERVICE [IMAGE]`](#jamsocket-push-service-image)
 * [`jamsocket service create NAME`](#jamsocket-service-create-name)
 * [`jamsocket service delete NAME`](#jamsocket-service-delete-name)
 * [`jamsocket service images SERVICE`](#jamsocket-service-images-service)
@@ -243,26 +243,30 @@ EXAMPLES
   $ jamsocket logs f7em2
 ```
 
-## `jamsocket push SERVICE IMAGE`
+## `jamsocket push SERVICE [IMAGE]`
 
-Pushes a docker image to the jamcr.io container registry under your logged in user's name.
+Builds and pushes an image to Jamsocket's container registry using the provided Dockerfile.
 
 ```
 USAGE
-  $ jamsocket push [SERVICE] [IMAGE] [-t <value>]
+  $ jamsocket push [SERVICE] [IMAGE] [-f <value>] [-c <value>] [-t <value>]
 
 ARGUMENTS
   SERVICE  Jamsocket service to push the image to
-  IMAGE    Docker image to push
+  IMAGE    Optionally, provide an image to push instead of a Dockerfile
 
 FLAGS
-  -t, --tag=<value>  optional tag to apply to the image in the jamsocket registry
+  -c, --context=<value>     path to the build context for the Dockerfile (defaults to current working directory)
+  -f, --dockerfile=<value>  path to the Dockerfile to build the image from
+  -t, --tag=<value>         optional tag to apply to the image in the jamsocket registry
 
 DESCRIPTION
-  Pushes a docker image to the jamcr.io container registry under your logged in user's name.
+  Builds and pushes an image to Jamsocket's container registry using the provided Dockerfile.
 
 EXAMPLES
-  $ jamsocket push my-service my-image
+  $ jamsocket push my-service -f path/to/Dockerfile
+
+  $ jamsocket push my-service -f path/to/Dockerfile -c .
 
   $ jamsocket push my-service my-image -t my-tag
 ```

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/cli/src/commands/backend/logs.ts
+++ b/cli/src/commands/backend/logs.ts
@@ -1,5 +1,6 @@
 import { Command } from '@oclif/core'
 import { Jamsocket } from '../../jamsocket'
+import { blue } from '../../formatting'
 
 export default class Logs extends Command {
     static description = 'Stream logs from a running backend.'
@@ -15,6 +16,9 @@ export default class Logs extends Command {
     public async run(): Promise<void> {
       const jamsocket = Jamsocket.fromEnvironment()
       const { args } = await this.parse(Logs)
+
+      console.log(blue('Reminder: you can find help troubleshooting common issues at https://docs.jamsocket.com/platform/troubleshooting'))
+      console.log()
 
       const logsStream = jamsocket.streamLogs(args.backend, line => {
         this.log(line)

--- a/cli/src/commands/push.ts
+++ b/cli/src/commands/push.ts
@@ -2,48 +2,79 @@ import { Command, Flags } from '@oclif/core'
 import chalk from 'chalk'
 import * as inquirer from 'inquirer'
 import { Jamsocket } from '../jamsocket'
-import { getImagePlatform } from '../docker'
-import { lightMagenta } from '../formatting'
+import { getImagePlatform, buildImage } from '../docker'
+import { lightMagenta, blue } from '../formatting'
 
 export default class Push extends Command {
-  static description = 'Pushes a docker image to the jamcr.io container registry under your logged in user\'s name.'
+  static description = 'Builds and pushes an image to Jamsocket\'s container registry using the provided Dockerfile.'
 
   static examples = [
-    '<%= config.bin %> <%= command.id %> my-service my-image',
+    '<%= config.bin %> <%= command.id %> my-service -f path/to/Dockerfile',
+    '<%= config.bin %> <%= command.id %> my-service -f path/to/Dockerfile -c .',
     '<%= config.bin %> <%= command.id %> my-service my-image -t my-tag',
   ]
 
   static flags = {
+    dockerfile: Flags.string({ char: 'f', description: 'path to the Dockerfile to build the image from' }),
+    context: Flags.string({ char: 'c', description: 'path to the build context for the Dockerfile (defaults to current working directory)' }),
     tag: Flags.string({ char: 't', description: 'optional tag to apply to the image in the jamsocket registry' }),
   }
 
   static args = [
     { name: 'service', description: 'Jamsocket service to push the image to', required: true },
-    { name: 'image', description: 'Docker image to push', required: true },
+    { name: 'image', description: 'Optionally, provide an image to push instead of a Dockerfile', required: false },
   ]
 
   public async run(): Promise<void> {
     const jamsocket = Jamsocket.fromEnvironment()
     const { args, flags } = await this.parse(Push)
-    const { os, arch } = getImagePlatform(args.image)
-    if (os !== 'linux' || arch !== 'amd64') {
-      this.log()
-      this.warn(chalk.bold.red`The image ${args.image} may not be compatible with Jamsocket because its image os/arch is ${os}/${arch}.`)
-      this.log('If you encounter errors while spawning with this image, you may need to rebuild the image with the platform flag (--platform=linux/amd64) and push again.')
-      this.log()
 
-      const response = await inquirer.prompt([{
-        name: 'goAhead',
-        message: lightMagenta('Go ahead and push image?'),
-        type: 'list',
-        choices: [{ name: 'no' }, { name: 'yes' }],
-      }])
-
-      if (response.goAhead !== 'yes') {
-        this.log('Image push canceled.')
-        return
-      }
+    // make sure either Dockerfile or an image is provided (not both or neither)
+    if (Boolean(args.image) === Boolean(flags.dockerfile)) {
+      this.error('Either an image or a Dockerfile must be provided. Rerun with --help for more information.')
     }
-    await jamsocket.push(args.service, args.image, flags.tag)
+
+    let image: string | null = null
+
+    if (args.image) {
+      if (flags.context !== undefined) {
+        throw new Error('--context flag should only be used with the --dockerfile flag')
+      }
+      const { os, arch } = getImagePlatform(args.image)
+      if (os !== 'linux' || arch !== 'amd64') {
+        this.log()
+        this.warn(chalk.bold.red`The image ${args.image} may not be compatible with Jamsocket because its image os/arch is ${os}/${arch}.`)
+        this.log('If you encounter errors while spawning with this image, you may need to rebuild the image with the platform flag (--platform=linux/amd64) and push again.')
+        this.log()
+
+        const response = await inquirer.prompt([{
+          name: 'goAhead',
+          message: lightMagenta('Go ahead and push image?'),
+          type: 'list',
+          choices: [{ name: 'no' }, { name: 'yes' }],
+        }])
+
+        if (response.goAhead !== 'yes') {
+          this.log('Image push canceled.')
+          return
+        }
+      }
+      image = args.image
+    }
+
+    if (flags.dockerfile) {
+      const options = flags.context ? { path: flags.context } : undefined
+      this.log(blue(`Building image from Dockerfile: ${flags.dockerfile}`))
+      image = await buildImage(flags.dockerfile, options)
+    }
+
+    if (!image) {
+      // we should never encounter this error because of the check at the beginning of the function
+      this.error('Error building/finding image.')
+    }
+
+    this.log()
+    this.log(blue('Pushing image to Jamsocket...'))
+    await jamsocket.push(args.service, image, flags.tag)
   }
 }

--- a/cli/src/dev-server/index.ts
+++ b/cli/src/dev-server/index.ts
@@ -221,7 +221,7 @@ class DevServer {
     this.logger.clearFooter()
     let imageId: string
     try {
-      imageId = buildImage(dockerfile, dockerOptions)
+      imageId = await buildImage(dockerfile, dockerOptions)
     } catch (error) {
       this.currentImageId = null
       const msg = error instanceof Error ? error.toString() : 'Unknown error'

--- a/cli/src/dev-server/plane.ts
+++ b/cli/src/dev-server/plane.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk'
 import EventSource from 'eventsource'
 import { SpawnResult, HTTPError } from '../api'
 import { capitalize } from './util'
+import { spawnDockerSync } from '../docker'
 import type { Logger } from './logger'
 
 export type PlaneConnectResponse = {
@@ -300,19 +301,11 @@ export function ensurePlaneImage(): Promise<void> {
   if (result.status === 0) return Promise.resolve()
   return new Promise((resolve, reject) => {
     console.log('Downloading plane/quickstart image...')
-    const pullProcess = spawn('docker', ['pull', PLANE_IMAGE])
-    pullProcess.stdout.on('data', data => {
-      process.stdout.write(data)
-    })
-    pullProcess.stderr.on('data', data => {
-      process.stdout.write(data)
-    })
-    pullProcess.on('exit', () => {
-      if (pullProcess.exitCode === 0) {
-        resolve()
-      } else {
-        reject()
-      }
-    })
+    const result = spawnDockerSync(['pull', PLANE_IMAGE], { stdio: 'inherit' })
+    if (result.status === 0) {
+      resolve()
+    } else {
+      reject(new Error('Failed to pull plane/quickstart image'))
+    }
   })
 }

--- a/cli/src/docker.ts
+++ b/cli/src/docker.ts
@@ -72,7 +72,7 @@ export function tag(existingImageName: string, newImageName: string): void {
   spawnDockerSync(['tag', existingImageName, newImageName], { stdio: 'inherit' })
 }
 
-function spawnDockerSync(args: string[], options?: { stdio?: StdioOptions }): SpawnSyncReturns<string> {
+export function spawnDockerSync(args: string[], options?: { stdio?: StdioOptions }): SpawnSyncReturns<string> {
   const opts: SpawnSyncOptionsWithStringEncoding = { encoding: 'utf-8', ...options }
   const result = spawnSync('docker', args, opts)
   const exitCode = result.status


### PR DESCRIPTION
This updates a few things in the Jamsocket CLI:

- [x] gives a better docker error when using the dev command for the first time
- [x] adds a link to the troubleshooting page at the top of the logs command
- [x] adds a `--dockerfile` and `--context` flag to the push command to allow users to just point to a Dockerfile when pushing instead of having to run `docker build --platform=linux/amd64 ...` separately.
- [x] bumps the version to `v0.8.11`