### PR TITLE
support static tokens in dev cli, add terminate endpoint to dev cli, etc

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.8.14",
+      "version": "0.8.15",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/cli/src/commands/backend/info.ts
+++ b/cli/src/commands/backend/info.ts
@@ -1,7 +1,7 @@
 import { Command } from '@oclif/core'
 import chalk from 'chalk'
 import { Jamsocket } from '../../jamsocket'
-import { blue, lightBlue, lightMagenta } from '../../formatting'
+import { blue, lightBlue, lightMagenta, lightGreen } from '../../formatting'
 
 export default class Info extends Command {
   static description = 'Retrieves information about a backend given its name.'
@@ -17,6 +17,8 @@ export default class Info extends Command {
     const jamsocket = Jamsocket.fromEnvironment()
     const info = await jamsocket.backendInfo(args.backend)
 
+    const appBaseUrl = jamsocket.api.getAppBaseUrl()
+
     this.log(chalk.bold`Info for backend: ${lightMagenta(info.name)}`)
     this.log(`created:      ${blue(info.created_at)}`)
     this.log(`service:      ${blue(info.service_name)}`)
@@ -26,6 +28,7 @@ export default class Info extends Command {
     if (info.lock) this.log(`lock:         ${blue(info.lock)}`)
     if (info.environment_name) this.log(`environment:  ${blue(info.environment_name)}`)
     if (info.max_mem_bytes) this.log(`mem usage:    ${blue(`${info.max_mem_bytes} bytes`)}`)
+    this.log(`dashboard:    ${lightGreen(`${appBaseUrl}/backend/${info.name}`)}`)
     this.log()
     this.log(chalk.bold`Statuses:`)
     if (info.statuses.length === 0) {

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -12,6 +12,7 @@ type ProjectConfig = {
   watch?: string | string[],
   port?: number
   interactive?: boolean,
+  useStaticToken?: boolean,
   dockerOptions?: {
     path?: string
   }
@@ -23,6 +24,7 @@ function isProjectConfig(obj: any): obj is ProjectConfig {
   if (obj.watch && typeof obj.watch !== 'string' && !Array.isArray(obj.watch)) return false
   if (obj.port && typeof obj.port !== 'number') return false
   if (obj.interactive && typeof obj.interactive !== 'boolean') return false
+  if (obj.useStaticToken && typeof obj.useStaticToken !== 'boolean') return false
   if (obj.dockerOptions) {
     if (typeof obj.dockerOptions !== 'object' || obj.dockerOptions === null) return false
     if (obj.dockerOptions.path && typeof obj.dockerOptions.path !== 'string') return false
@@ -71,6 +73,7 @@ export default class Dev extends Command {
     watch: Flags.string({ char: 'w', multiple: true, description: 'A file or directory to watch for changes' }),
     port: Flags.integer({ char: 'p', description: 'The port to run the dev server on. (Defaults to 8080)' }),
     interactive: Flags.boolean({ char: 'i', description: 'Enables/Disables TTY iteractivity. (Defaults to true)', allowNo: true }),
+    'use-static-token': Flags.boolean({ char: 's', hidden: true, description: 'Makes session backends use a static connection token instead of generating a new one with each spawn/connect request. (Defaults to false)', allowNo: false }),
   }
 
   public async run(): Promise<void> {
@@ -97,12 +100,15 @@ export default class Dev extends Command {
       dockerOptions.path = path.resolve(process.cwd(), dockerContext)
     }
 
+    const useStaticToken = flags['use-static-token'] ?? projectConfig?.useStaticToken ?? undefined
+
     await createDevServer({
       dockerfile: path.resolve(process.cwd(), dockerfile),
       watch: watch?.map(w => path.resolve(process.cwd(), w)),
       port,
       interactive,
       dockerOptions,
+      useStaticToken,
     })
   }
 }

--- a/cli/src/commands/service/info.ts
+++ b/cli/src/commands/service/info.ts
@@ -2,7 +2,7 @@ import { Command } from '@oclif/core'
 import chalk from 'chalk'
 import { formatDistanceToNow } from 'date-fns'
 import { Jamsocket } from '../../jamsocket'
-import { blue, gray, lightBlue, lightMagenta } from '../../formatting'
+import { blue, gray, lightBlue, lightMagenta, lightGreen } from '../../formatting'
 
 export default class Create extends Command {
   static description = 'Gets some information about a service'
@@ -19,6 +19,8 @@ export default class Create extends Command {
     const jamsocket = Jamsocket.fromEnvironment()
     const info = await jamsocket.serviceInfo(args.name)
 
+    const appBaseUrl = jamsocket.api.getAppBaseUrl()
+
     const lastSpawn = info.last_spawned_at ? blue(`${formatDistanceToNow(new Date(info.last_spawned_at))} ago`) : '-'
     let lastPush = '-'
     if (info.last_image_upload_time) {
@@ -33,6 +35,7 @@ export default class Create extends Command {
     this.log(`  created: ${blue(`${formatDistanceToNow(new Date(info.created_at))} ago`)}`)
     this.log(`  last spawn: ${lastSpawn}`)
     this.log(`  last image push: ${lastPush}`)
+    this.log(`  dashboard: ${lightGreen(`${appBaseUrl}/service/${info.name}`)}`)
 
     if (info.environments.length > 1) {
       this.log()

--- a/cli/src/commands/service/spawn.ts
+++ b/cli/src/commands/service/spawn.ts
@@ -2,7 +2,7 @@ import { Command, Flags } from '@oclif/core'
 import chalk from 'chalk'
 import { Jamsocket } from '../../jamsocket'
 import * as customFlags from '../../flags'
-import { blue, lightBlue } from '../../formatting'
+import { blue, lightBlue, lightGreen } from '../../formatting'
 
 export default class Spawn extends Command {
   static aliases = ['spawn']
@@ -43,6 +43,8 @@ export default class Spawn extends Command {
     const jamsocket = Jamsocket.fromEnvironment()
     const responseBody = await jamsocket.spawn(service, environment, env, flags.grace, flags.lock)
 
+    const appBaseUrl = jamsocket.api.getAppBaseUrl()
+
     this.log(lightBlue('Backend spawned!'))
     this.log(chalk.bold`backend name:   `, blue(responseBody.name))
     this.log(chalk.bold`backend status: `, blue(responseBody.status ?? '-'))
@@ -52,5 +54,6 @@ export default class Spawn extends Command {
     if (flags.lock) {
       this.log(chalk.bold`spawned:        `, blue(responseBody.spawned.toString()))
     }
+    this.log(chalk.bold`dashboard:      `, lightGreen(`${appBaseUrl}/backend/${responseBody.name}`))
   }
 }

--- a/cli/src/dev-server/plane.ts
+++ b/cli/src/dev-server/plane.ts
@@ -186,17 +186,22 @@ export class LocalPlane {
     env?: Record<string, string>,
     gracePeriodSeconds?: number,
     lock?: string,
+    useStaticToken?: boolean,
   ): Promise<SpawnResult | HTTPError> {
     const spawnUrl = `${this.url}/ctrl/connect`
+    const spawnConfig: Record<string, any> = {
+      executable: { image, env, pull_policy: 'Never' },
+      max_idle_seconds: gracePeriodSeconds,
+    }
+    if (useStaticToken) {
+      spawnConfig.use_static_token = true
+    }
     const spawnBody = {
       key: lock ? {
         name: lock,
         tag: image,
       } : undefined,
-      spawn_config: {
-        executable: { image, env, pull_policy: 'Never' },
-        max_idle_seconds: gracePeriodSeconds,
-      },
+      spawn_config: spawnConfig,
     }
     const response = await fetch(spawnUrl, {
       method: 'POST',

--- a/cli/src/dev-server/plane.ts
+++ b/cli/src/dev-server/plane.ts
@@ -39,7 +39,7 @@ export type StreamHandle = {
   close: () => void
 }
 
-const PLANE_IMAGE = 'plane/quickstart:sha-cf3e780'
+const PLANE_IMAGE = 'plane/quickstart:sha-2e2cbe4'
 const LAST_N_PLANE_LOGS = 20 // the number of plane logs to show if a Plane error is enountered
 
 // NOTE: this class works with a Plane2 interface, but its own interface is meant to be compatible with Jamsocket V1

--- a/cli/src/jamsocket.ts
+++ b/cli/src/jamsocket.ts
@@ -5,7 +5,7 @@ import { tag as dockerTag, push as dockerPush } from './docker'
 import type { EventStreamReturn } from './request'
 
 export class Jamsocket {
-  constructor(public config: JamsocketConfig | null, private api: JamsocketApi) {}
+  constructor(public config: JamsocketConfig | null, public api: JamsocketApi) {}
 
   public static fromEnvironment(): Jamsocket {
     const config = JamsocketConfig.fromSaved()


### PR DESCRIPTION
This also upgrades the dev cli to use the latest version of Plane, adds links to the dashboard from the `service info`, `backend info`, and `spawn` commands, and bumps to version `v0.8.15`.