### PR TITLE
support --docker-network arg for dev cli

### DIFF
--- a/cli/.eslintrc
+++ b/cli/.eslintrc
@@ -14,6 +14,7 @@
     // no-useless-constructor triggers false positives with typescript
     // constructor assignment.
     "no-useless-constructor": "off",
-    "max-params": ["warn", 6]
+    "max-params": ["warn", 6],
+    "complexity": "off"
   }
 }

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.8.18",
+      "version": "0.8.19",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.8.19",
+      "version": "0.8.20",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'fs'
 import path from 'path'
 import { Command, Flags } from '@oclif/core'
 import { createDevServer } from '../dev-server'
-import type { BuildImageOptions } from '../docker'
+import { type BuildImageOptions, getDockerNetworks } from '../docker'
 
 const PROJECT_CONFIG_PATH_JS = path.resolve(process.cwd(), 'jamsocket.config.js')
 const PROJECT_CONFIG_PATH_JSON = path.resolve(process.cwd(), 'jamsocket.config.json')
@@ -104,6 +104,13 @@ export default class Dev extends Command {
     }
 
     const dockerNetwork = flags['docker-network'] ?? projectConfig?.dockerOptions?.network ?? undefined
+
+    if (dockerNetwork) {
+      const availableDockerNetworks = getDockerNetworks()
+      if (!availableDockerNetworks.includes(dockerNetwork)) {
+        throw new Error(`Docker network "${dockerNetwork}" not found. Available networks: ${availableDockerNetworks.join(', ')}`)
+      }
+    }
 
     const useStaticToken = flags['use-static-token'] ?? projectConfig?.useStaticToken ?? undefined
 

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -14,7 +14,8 @@ type ProjectConfig = {
   interactive?: boolean,
   useStaticToken?: boolean,
   dockerOptions?: {
-    path?: string
+    path?: string,
+    network?: string,
   }
 }
 
@@ -28,6 +29,7 @@ function isProjectConfig(obj: any): obj is ProjectConfig {
   if (obj.dockerOptions) {
     if (typeof obj.dockerOptions !== 'object' || obj.dockerOptions === null) return false
     if (obj.dockerOptions.path && typeof obj.dockerOptions.path !== 'string') return false
+    if (obj.dockerOptions.network && typeof obj.dockerOptions.network !== 'string') return false
   }
   return true
 }
@@ -70,6 +72,7 @@ export default class Dev extends Command {
     dockerfileold: Flags.string({ char: 'd', description: 'Path to the session backend\'s Dockerfile', hidden: true }),
     dockerfile: Flags.string({ char: 'f', description: 'Path to the session backend\'s Dockerfile' }),
     context: Flags.string({ char: 'c', description: 'Path to the build context for the Dockerfile (defaults to current working directory)' }),
+    'docker-network': Flags.string({ char: 'n', hidden: true, description: 'The Docker network to use for the session backend (only for development)' }),
     watch: Flags.string({ char: 'w', multiple: true, description: 'A file or directory to watch for changes' }),
     port: Flags.integer({ char: 'p', description: 'The port to run the dev server on. (Defaults to 8080)' }),
     interactive: Flags.boolean({ char: 'i', description: 'Enables/Disables TTY iteractivity. (Defaults to true)', allowNo: true }),
@@ -100,6 +103,8 @@ export default class Dev extends Command {
       dockerOptions.path = path.resolve(process.cwd(), dockerContext)
     }
 
+    const dockerNetwork = flags['docker-network'] ?? projectConfig?.dockerOptions?.network ?? undefined
+
     const useStaticToken = flags['use-static-token'] ?? projectConfig?.useStaticToken ?? undefined
 
     await createDevServer({
@@ -109,6 +114,7 @@ export default class Dev extends Command {
       interactive,
       dockerOptions,
       useStaticToken,
+      dockerNetwork,
     })
   }
 }

--- a/cli/src/dev-server/plane.ts
+++ b/cli/src/dev-server/plane.ts
@@ -39,7 +39,7 @@ export type StreamHandle = {
   close: () => void
 }
 
-const PLANE_IMAGE = 'plane/quickstart:sha-8a0f9b6'
+const PLANE_IMAGE = 'plane/quickstart:sha-7b65d54'
 const LAST_N_PLANE_LOGS = 20 // the number of plane logs to show if a Plane error is enountered
 
 // NOTE: this class works with a Plane2 interface, but its own interface is meant to be compatible with Jamsocket V1
@@ -187,6 +187,7 @@ export class LocalPlane {
     gracePeriodSeconds?: number,
     lock?: string,
     useStaticToken?: boolean,
+    dockerNetwork?: string,
   ): Promise<SpawnResult | HTTPError> {
     const spawnUrl = `${this.url}/ctrl/connect`
     const spawnConfig: Record<string, any> = {
@@ -195,6 +196,9 @@ export class LocalPlane {
     }
     if (useStaticToken) {
       spawnConfig.use_static_token = true
+    }
+    if (dockerNetwork) {
+      spawnConfig.executable.network_name = dockerNetwork
     }
     const spawnBody = {
       key: lock ? {

--- a/cli/src/docker.ts
+++ b/cli/src/docker.ts
@@ -97,6 +97,11 @@ export function tag(existingImageName: string, newImageName: string): void {
   spawnDockerSync(['tag', existingImageName, newImageName], { stdio: 'inherit' })
 }
 
+export function getDockerNetworks(): string[] {
+  const result = spawnDockerSync(['network', 'ls', '--format', '{{.Name}}'])
+  return result.stdout.split('\n').filter(Boolean)
+}
+
 export function spawnDockerSync(args: string[], options?: { stdio?: StdioOptions }): SpawnSyncReturns<string> {
   const opts: SpawnSyncOptionsWithStringEncoding = { encoding: 'utf-8', ...options }
   const result = spawnSync('docker', args, opts)


### PR DESCRIPTION
This adds support to the dev CLI for passing in a custom `docker network` during development.

Usage:
```
npx jamsocket dev --docker-network foobar
```

Note: this network must exist before spawning backends, otherwise they will fail to start.