### PR TITLE
make cli support multiple accounts per user

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -26,7 +26,7 @@ If you want to use the Jamsocket CLI from an automated environment (e.g. a CI/CD
 * [`jamsocket dev`](#jamsocket-dev)
 * [`jamsocket help [COMMAND]`](#jamsocket-help-command)
 * [`jamsocket images SERVICE`](#jamsocket-images-service)
-* [`jamsocket login`](#jamsocket-login)
+* [`jamsocket login [ACCOUNT]`](#jamsocket-login-account)
 * [`jamsocket logout`](#jamsocket-logout)
 * [`jamsocket logs BACKEND`](#jamsocket-logs-backend)
 * [`jamsocket push SERVICE [IMAGE]`](#jamsocket-push-service-image)
@@ -190,13 +190,16 @@ EXAMPLES
   $ jamsocket images my-service
 ```
 
-## `jamsocket login`
+## `jamsocket login [ACCOUNT]`
 
 Authenticates user to the Jamsocket API.
 
 ```
 USAGE
-  $ jamsocket login [-t <value>]
+  $ jamsocket login [ACCOUNT] [-t <value>]
+
+ARGUMENTS
+  ACCOUNT  Account to use when logging in. (Only necessary for users with multiple accounts.)
 
 FLAGS
   -t, --token=<value>  for automated environments, optional API token to log into the CLI with

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.8.20",
+      "version": "0.8.21",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -9,7 +9,7 @@ enum HttpMethod {
 
 export type CheckAuthResult = {
   status: 'ok';
-  account: string | null;
+  // account: string | null; // this is now deprecated
   accounts: string[];
 }
 

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -263,65 +263,65 @@ export class JamsocketApi {
     return this.makeAuthenticatedRequest<CheckAuthResult>(url, HttpMethod.Get, authToken)
   }
 
-  public serviceImage(username: string, serviceName: string, authToken: string): Promise<ServiceImageResult> {
-    const url = `/user/${username}/service/${serviceName}/image`
+  public serviceImage(accountName: string, serviceName: string, authToken: string): Promise<ServiceImageResult> {
+    const url = `/v2/service/${accountName}/${serviceName}/image-name`
     return this.makeAuthenticatedRequest<ServiceImageResult>(url, HttpMethod.Get, authToken)
   }
 
-  public serviceCreate(username: string, name: string, authToken: string): Promise<ServiceCreateResult> {
-    const url = `/user/${username}/service`
+  public serviceCreate(accountName: string, name: string, authToken: string): Promise<ServiceCreateResult> {
+    const url = `/v2/account/${accountName}/service`
     return this.makeAuthenticatedRequest<ServiceCreateResult>(url, HttpMethod.Post, authToken, {
       name,
     })
   }
 
-  public serviceDelete(username: string, serviceName: string, authToken: string): Promise<ServiceDeleteResult> {
-    const url = `/user/${username}/service/${serviceName}/delete`
+  public serviceDelete(accountName: string, serviceName: string, authToken: string): Promise<ServiceDeleteResult> {
+    const url = `/v2/service/${accountName}/${serviceName}/delete`
     return this.makeAuthenticatedRequest<ServiceDeleteResult>(url, HttpMethod.Post, authToken)
   }
 
-  public serviceInfo(username: string, serviceName: string, authToken: string): Promise<ServiceInfoResult> {
-    const url = `/user/${username}/service/${serviceName}`
+  public serviceInfo(accountName: string, serviceName: string, authToken: string): Promise<ServiceInfoResult> {
+    const url = `/v2/service/${accountName}/${serviceName}`
     return this.makeAuthenticatedRequest<ServiceInfoResult>(url, HttpMethod.Get, authToken)
   }
 
-  public serviceList(username: string, authToken: string): Promise<ServiceListResult> {
-    const url = `/user/${username}/services`
+  public serviceList(accountName: string, authToken: string): Promise<ServiceListResult> {
+    const url = `/v2/account/${accountName}/services`
     return this.makeAuthenticatedRequest<ServiceListResult>(url, HttpMethod.Get, authToken)
   }
 
-  public updateEnvironment(account: string, service: string, environment: string, authToken: string, body: UpdateEnvironmentBody): Promise<EnvironmentUpdateResult> {
-    const url = `/env/${account}/${service}/${environment}/update`
+  public updateEnvironment(accountName: string, service: string, environment: string, authToken: string, body: UpdateEnvironmentBody): Promise<EnvironmentUpdateResult> {
+    const url = `/v2/service-env/${accountName}/${service}/${environment}/update`
     return this.makeAuthenticatedRequest<EnvironmentUpdateResult>(url, HttpMethod.Post, authToken, body)
   }
 
-  public spawn(username: string, serviceName: string, authToken: string, body: SpawnRequestBody): Promise<SpawnResult> {
-    const url = `/user/${username}/service/${serviceName}/spawn`
+  public spawn(accountName: string, serviceName: string, authToken: string, body: SpawnRequestBody): Promise<SpawnResult> {
+    const url = `/v1/user/${accountName}/service/${serviceName}/spawn`
     return this.makeAuthenticatedRequest<SpawnResult>(url, HttpMethod.Post, authToken, body)
   }
 
-  public listRunningBackends(username: string, authToken: string): Promise<RunningBackendsResult> {
-    const url = `/user/${username}/backends`
+  public listRunningBackends(accountName: string, authToken: string): Promise<RunningBackendsResult> {
+    const url = `/v2/account/${accountName}/backends`
     return this.makeAuthenticatedRequest<RunningBackendsResult>(url, HttpMethod.Get, authToken)
   }
 
-  public imagesList(account: string, serviceName: string, authToken: string): Promise<ServiceImagesResult> {
-    const url = `/user/${account}/service/${serviceName}/images`
+  public imagesList(accountName: string, serviceName: string, authToken: string): Promise<ServiceImagesResult> {
+    const url = `/v2/service/${accountName}/${serviceName}/images`
     return this.makeAuthenticatedRequest<ServiceImagesResult>(url, HttpMethod.Get, authToken)
   }
 
   public streamLogs(backend: string, authToken: string, callback: (line: string) => void): EventStreamReturn {
-    const url = `/backend/${backend}/logs`
+    const url = `/v2/backend/${backend}/logs`
     return this.makeAuthenticatedStreamRequest(url, authToken, callback)
   }
 
   public streamMetrics(backend: string, authToken: string, callback: (line: string) => void): EventStreamReturn {
-    const url = `/backend/${backend}/metrics/stream`
+    const url = `/v2/backend/${backend}/metrics/stream`
     return this.makeAuthenticatedStreamRequest(url, authToken, callback)
   }
 
   public streamStatus(backend: string, callback: (statusMessage: StatusMessage) => void): EventStreamReturn {
-    const url = `/backend/${backend}/status/stream`
+    const url = `/v1/backend/${backend}/status/stream`
     const wrappedCallback = (line: string) => {
       const val = JSON.parse(line)
       callback({
@@ -333,37 +333,37 @@ export class JamsocketApi {
   }
 
   public async status(backend: string): Promise<StatusMessage> {
-    const url = `/backend/${backend}/status`
+    const url = `/v1/backend/${backend}/status`
     return this.makeRequest<StatusMessage>(url, HttpMethod.Get)
   }
 
   public async terminate(backend: string, authToken: string): Promise<TerminateResult> {
-    const url = `/backend/${backend}/terminate`
+    const url = `/v2/backend/${backend}/terminate`
     return this.makeAuthenticatedRequest<TerminateResult>(url, HttpMethod.Post, authToken)
   }
 
   public async backendInfo(backend: string, authToken: string): Promise<BackendInfoResult> {
-    const url = `/backend/${backend}`
+    const url = `/v1/backend/${backend}`
     return this.makeAuthenticatedRequest<BackendInfoResult>(url, HttpMethod.Get, authToken)
   }
 
   public async startLoginAttempt(): Promise<CliLoginAttemptResult> {
-    const url = '/cli_login'
+    const url = '/cli-login'
     return this.makeRequest<CliLoginAttemptResult>(url, HttpMethod.Post, {})
   }
 
   public async completeLoginAttempt(token: string, code: string): Promise<CompleteCliLoginResult> {
-    const url = `/cli_login/${token}/complete`
+    const url = `/cli-login/${token}/complete`
     return this.makeRequest<CompleteCliLoginResult>(url, HttpMethod.Post, { code })
   }
 
   public async revokeUserSession(userSessionId: string, authToken: string): Promise<UserSessionRevokeResult> {
-    const url = `/user_session/${userSessionId}`
-    return this.makeAuthenticatedRequest<UserSessionRevokeResult>(url, HttpMethod.Delete, authToken)
+    const url = `/user-session/${userSessionId}/delete`
+    return this.makeAuthenticatedRequest<UserSessionRevokeResult>(url, HttpMethod.Post, authToken)
   }
 
   public streamLoginStatus(loginToken: string): Promise<boolean> {
-    const endpoint = `/cli_login/${loginToken}/status/stream`
+    const endpoint = `/cli-login/${loginToken}/status/stream`
     const url = `${this.apiBase}${endpoint}`
     // right now, this stream only returns a single message and then closes
     return new Promise(resolve => {

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,6 +1,7 @@
 import { Command, CliUx, Flags } from '@oclif/core'
 import chalk from 'chalk'
-import { JamsocketApi, AuthenticationError } from '../api'
+import * as inquirer from 'inquirer'
+import { JamsocketApi, AuthenticationError, CompleteCliLoginResult } from '../api'
 import { deleteJamsocketConfig, JamsocketConfig } from '../jamsocket-config'
 import { lightMagenta, lightGreen, lightBlue, gradientBlue } from '../formatting'
 
@@ -11,6 +12,10 @@ export default class Login extends Command {
     '<%= config.bin %> <%= command.id %>',
   ]
 
+  static args = [
+    { name: 'account', description: 'Account to use when logging in. (Only necessary for users with multiple accounts.)', required: false },
+  ]
+
   static flags = {
     token: Flags.string({ char: 't', description: 'for automated environments, optional API token to log into the CLI with' }),
   }
@@ -18,22 +23,54 @@ export default class Login extends Command {
   public async run(): Promise<void> {
     const api = JamsocketApi.fromEnvironment()
     const savedConfig = JamsocketConfig.fromSaved()
+
+    const { flags, args } = await this.parse(Login)
+    const requestedAccount = args.account
+
     if (savedConfig !== null) {
       const token = savedConfig.getAccessToken()
       try {
         const result = await api.checkAuth(token)
         this.log()
-        if (result.account === null) throw new Error(`No account found for logged in user. You may need to log in to ${api.getAppBaseUrl()} to finish setting up your account.`)
-        this.log(`You are already logged into account ${lightBlue(result.account)}. To log into a different account, run ${lightMagenta('jamsocket logout')} first.\n`)
+        if (result.accounts.length === 0) throw new Error(`No account found for logged in user. You may need to log in to ${api.getAppBaseUrl()} to finish setting up your account.`)
+
+        // if logged in with api token, say "You are already logged in as account" and drop out
+        if (savedConfig.loggedInType() === 'api_token') {
+          this.log(`You are already logged in as account ${lightBlue(savedConfig.getAccount())}. To log into a different account, run ${lightMagenta('jamsocket logout')} first.\n`)
+          return
+        }
+
+        // if did not request an account, say "You are already logged in as account" and drop out
+        if (!requestedAccount) {
+          this.log(`You are already logged in as account ${lightBlue(savedConfig.getAccount())}.\n`)
+
+          if (result.accounts.length > 1) {
+            this.log(`Run ${lightMagenta('jamsocket login <account>')} to switch to one of the following accounts: ${result.accounts.map(n => lightBlue(n)).join(', ')}.\n`)
+            this.log(`Otherwise, run ${lightMagenta('jamsocket logout')} first to log into an account not listed here.\n`)
+          } else {
+            this.log(`To log into a different account, run ${lightMagenta('jamsocket logout')} first.\n`)
+          }
+          return
+        }
+
+        // if requested an account, check that the account is in the list of accounts
+        // if it is, update the primary account and say "You are now logged in as account"
+        if (result.accounts.includes(requestedAccount)) {
+          savedConfig.updateSelectedAccount(requestedAccount)
+          savedConfig.save()
+          this.log(`You're logged in as ${lightBlue(requestedAccount)}\n`)
+          return
+        }
+
+        // if it is not, fail
+        this.log(`You do not have access to account ${lightBlue(requestedAccount)}.`)
         return
       } catch (error) {
+        deleteJamsocketConfig()
         const isAuthError = error instanceof AuthenticationError
         if (!isAuthError) throw error
-        deleteJamsocketConfig()
       }
     }
-
-    const { flags } = await this.parse(Login)
 
     const token = flags.token?.trim()
 
@@ -43,8 +80,16 @@ export default class Login extends Command {
         throw new Error('Invalid token. Token must contain a period.')
       }
 
-      const { account } = await api.checkAuth(token)
-      if (account === null) throw new Error(`No account found for user. You may need to log in to ${api.getAppBaseUrl()} to finish setting up your account.`)
+      const { accounts } = await api.checkAuth(token)
+      this.log()
+      if (accounts.length === 0) throw new Error(`No account found for user. You may need to log in to ${api.getAppBaseUrl()} to finish setting up your account.`)
+      // an api token can only be used for one account, so this should be the only account in the list
+      const account = accounts[0]
+
+      if (requestedAccount && requestedAccount !== account) {
+        throw new Error(`You do not have access to account "${requestedAccount}".`)
+      }
+
       const config = new JamsocketConfig({ api_token: { account, token } })
       config.save()
       this.log(`Logged in using API token as "${account}"`)
@@ -70,20 +115,58 @@ export default class Login extends Command {
     const userSession = await api.completeLoginAttempt(loginAttempt.token, code)
     const authResult = await api.checkAuth(userSession.token)
 
-    if (authResult.account === null) throw new Error(`No account found for user. You may need to ${lightMagenta(`log in to ${api.getAppBaseUrl()}`)} to finish setting up your account.`)
+    if (authResult.accounts.length === 0) throw new Error(`No account found for user. You may need to ${lightMagenta(`log in to ${api.getAppBaseUrl()}`)} to finish setting up your account.`)
 
+    // if they requested an account, check if that account is in the list of accounts
+    if (requestedAccount) {
+      if (authResult.accounts.includes(requestedAccount)) {
+        this.finalizeUserSessionLogin(userSession, requestedAccount)
+        return
+      }
+
+      throw new Error(`You do not have access to account ${lightBlue(requestedAccount)}.`)
+    }
+
+    // otherwise, they did not request a specific account...
+    // if they only have one account, then use that account
+    if (authResult.accounts.length === 1) {
+      this.finalizeUserSessionLogin(userSession, authResult.accounts[0])
+      return
+    }
+
+    // otherwise, they have multiple accounts, so prompt them to select an account
+    this.log()
+    const response = await inquirer.prompt([{
+      name: 'account',
+      message: 'You have access to multiple accounts. Please specify which account you would like to use.',
+      type: 'list',
+      choices: authResult.accounts.map(account => ({ name: account })),
+    }])
+
+    if (response.account !== null) {
+      this.finalizeUserSessionLogin(userSession, response.account)
+      return
+    }
+
+    throw new Error('Auth failed. No account selected. Try running jamsocket login again.')
+  }
+
+  finalizeUserSessionLogin(
+    userSession: CompleteCliLoginResult,
+    selectedAccount: string,
+  ): void {
     const config = new JamsocketConfig({
       user_session: {
         uuid: userSession.uuid,
         user_id: userSession.user_id,
         token: userSession.token,
-        primary_account: authResult.account,
+        selected_account: selectedAccount,
       },
     })
     config.save()
 
     this.log()
     this.log(`Welcome to ${gradientBlue('Jamsocket')}!`)
-    this.log(`You're logged in as ${lightMagenta(authResult.account)}\n`)
+    this.log(`You're logged in as ${lightMagenta(selectedAccount)}\n`)
   }
 }

--- a/cli/src/commands/service/info.ts
+++ b/cli/src/commands/service/info.ts
@@ -35,7 +35,7 @@ export default class Create extends Command {
     this.log(`  created: ${blue(`${formatDistanceToNow(new Date(info.created_at))} ago`)}`)
     this.log(`  last spawn: ${lastSpawn}`)
     this.log(`  last image push: ${lastPush}`)
-    this.log(`  dashboard: ${lightGreen(`${appBaseUrl}/service/${info.name}`)}`)
+    this.log(`  dashboard: ${lightGreen(`${appBaseUrl}/service/${info.account_name}/${info.name}`)}`)
 
     if (info.environments.length > 1) {
       this.log()


### PR DESCRIPTION
Also use new api endpoints and update dashboard URLs to work with new paths.

You can test this by pulling the repo, running `npm run build` in the `cli` directory, and then using `cli/bin/run`, e.g. `cli/bin/run login` or `cli/bin/run login taylor`. Users with multiple accounts will have to select an account when logging in, or they can select which account they'd like to use by passing in the account name to the `login` command. This is also how you can switch between your user's accounts without having to go through the auth flow again.