### PR TITLE
add onStatus method

### DIFF
--- a/examples/multiplayer-editor/package.json
+++ b/examples/multiplayer-editor/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@jamsocket/server": "0.2.4",
-    "@jamsocket/socketio": "0.2.4",
+    "@jamsocket/server": "0.2.5",
+    "@jamsocket/socketio": "0.2.5",
     "@types/node": "20.1.4",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "prettier": "^3.2.5",
         "ts-node": "^10.9.2",
         "tsup": "^8.0.2",
-        "typescript": "^5.3.3"
+        "typescript": "^5.5.3"
       },
       "engines": {
         "node": ">=18"
@@ -5506,9 +5506,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,8 @@
     "examples/multiplayer-editor": {
       "version": "0.1.0",
       "dependencies": {
-        "@jamsocket/server": "0.2.4",
-        "@jamsocket/socketio": "0.2.4",
+        "@jamsocket/server": "0.2.5",
+        "@jamsocket/socketio": "0.2.5",
         "@types/node": "20.1.4",
         "@types/react": "18.2.6",
         "@types/react-dom": "18.2.4",
@@ -5867,15 +5867,15 @@
     },
     "packages/typescript/client": {
       "name": "@jamsocket/client",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT"
     },
     "packages/typescript/react": {
       "name": "@jamsocket/react",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/client": "0.2.4"
+        "@jamsocket/client": "0.2.5"
       },
       "devDependencies": {
         "@types/react": "^18.2.59"
@@ -5886,7 +5886,7 @@
     },
     "packages/typescript/server": {
       "name": "@jamsocket/server",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0"
@@ -5894,10 +5894,10 @@
     },
     "packages/typescript/socketio": {
       "name": "@jamsocket/socketio",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/react": "0.2.4",
+        "@jamsocket/react": "0.2.5",
         "socket.io-client": "^4.7.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "prettier": "^3.2.5",
     "ts-node": "^10.9.2",
     "tsup": "^8.0.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.5.3"
   }
 }

--- a/packages/typescript/client/package.json
+++ b/packages/typescript/client/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "JavaScript/TypeScript libraries for interacting with session backends and the Jamsocket platform.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/packages/typescript/client/src/main.ts
+++ b/packages/typescript/client/src/main.ts
@@ -94,6 +94,8 @@ export class SessionBackend {
             console.warn(`Skipping message from SSE endpoint: ${line}`)
             return null
           }
+
+          // remove the 'data: ' prefix
           const text = line.slice(5).trim()
           try {
             return JSON.parse(text) as StatusStreamEvent

--- a/packages/typescript/react/package.json
+++ b/packages/typescript/react/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "React hooks for interacting with session backends and the Jamsocket platform.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/client": "0.2.4"
+    "@jamsocket/client": "0.2.5"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"

--- a/packages/typescript/server/package.json
+++ b/packages/typescript/server/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "JavaScript/TypeScript libraries for spawning session backends server-side.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/packages/typescript/server/src/main.ts
+++ b/packages/typescript/server/src/main.ts
@@ -95,6 +95,11 @@ export function init(opts: JamsocketInitOptions): JamsocketInstance {
       cache: 'no-store',
     })
     if (!response.ok) {
+      if (response.status === 429) {
+        console.warn(
+          "You've hit the spawn rate limit. This may be because you've spawned too many session backends in a short period of time or you're already running the maximum number of concurrent session backends. (related: https://docs.jamsocket.com/pricing/free-tier-limits)",
+        )
+      }
       throw new Error(`Error spawning backend: ${response.status} ${await response.text()}`)
     }
     const body = await response.json()

--- a/packages/typescript/socketio/package.json
+++ b/packages/typescript/socketio/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "React hooks for interacting with socket.io servers in Jamsocket session backends.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/react": "0.2.4",
+    "@jamsocket/react": "0.2.5",
     "socket.io-client": "^4.7.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
This adds an `onStatus` method to the `SessionBackend` class. This means we need to stay subscribed to the status stream, so now we resubscribe if the stream closes but we haven't received a terminal backend status yet.

This also exposes some convenience promises for specific statuses, e.g.:

```ts
await backend.onReadyPromise
await backend.onTerminatedPromise
```