### PR TITLE
cli update to v2 endpoints and v2 statuses

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -23,6 +23,7 @@ If you want to use the Jamsocket CLI from an automated environment (e.g. a CI/CD
 * [`jamsocket backend logs BACKEND`](#jamsocket-backend-logs-backend)
 * [`jamsocket backend metrics BACKEND`](#jamsocket-backend-metrics-backend)
 * [`jamsocket backend terminate BACKENDS`](#jamsocket-backend-terminate-backends)
+* [`jamsocket connect SERVICE`](#jamsocket-connect-service)
 * [`jamsocket dev`](#jamsocket-dev)
 * [`jamsocket help [COMMAND]`](#jamsocket-help-command)
 * [`jamsocket images SERVICE`](#jamsocket-images-service)
@@ -30,6 +31,7 @@ If you want to use the Jamsocket CLI from an automated environment (e.g. a CI/CD
 * [`jamsocket logout`](#jamsocket-logout)
 * [`jamsocket logs BACKEND`](#jamsocket-logs-backend)
 * [`jamsocket push SERVICE [IMAGE]`](#jamsocket-push-service-image)
+* [`jamsocket service connect SERVICE`](#jamsocket-service-connect-service)
 * [`jamsocket service create NAME`](#jamsocket-service-create-name)
 * [`jamsocket service delete NAME`](#jamsocket-service-delete-name)
 * [`jamsocket service images SERVICE`](#jamsocket-service-images-service)
@@ -115,7 +117,10 @@ Terminates one or more backends given the backend name(s).
 
 ```
 USAGE
-  $ jamsocket backend terminate [BACKENDS]
+  $ jamsocket backend terminate [BACKENDS] [-f]
+
+FLAGS
+  -f, --force  whether to force the backend to hard terminate (defaults to false)
 
 DESCRIPTION
   Terminates one or more backends given the backend name(s).
@@ -125,6 +130,59 @@ ALIASES
 
 EXAMPLES
   $ jamsocket backend terminate abc123 def456 ...
+```
+
+## `jamsocket connect SERVICE`
+
+Gets a URL that can be used to connect to a session backend. Will spawn a new session backend if no key (aka lock) is provided or if no session backend is currently holding the provided key.
+
+```
+USAGE
+  $ jamsocket connect [SERVICE] [-e <value>] [-t <value>] [-i <value>] [-l <value>] [-k <value>] [-u <value>]
+    [-a <value>] [--spawn]
+
+ARGUMENTS
+  SERVICE  Name of service to spawn.
+
+FLAGS
+  -a, --auth=<value>                    Optional serialized JSON to be passed to a session backend when connecting with
+                                        the returned URL/connection string.
+  -e, --env=<value>...                  optional environment variables to pass to the container
+  -i, --max-idle-seconds=<value>        The max time in seconds a session backend should wait after last connection is
+                                        closed before shutting down container (default is 300)
+  -k, --key=<value>                     If provided, fetches the session backend currently holding the given key
+                                        (formerly known as a "lock"). If no session backend holds the key, or if a key
+                                        is not provided, a new session backend will be spawned.
+  -l, --lifetime-limit-seconds=<value>  The max time in seconds the session backend should be allowed to run.
+  -t, --tag=<value>                     An optional image tag or image digest to use when spawning a backend.
+  -u, --user=<value>                    Optional username to be associated with the URL/connection string returned by
+                                        the connect command.
+  --[no-]spawn                          Whether to spawn a new session backend if no session backend is currently
+                                        holding the provided key.
+
+DESCRIPTION
+  Gets a URL that can be used to connect to a session backend. Will spawn a new session backend if no key (aka lock) is
+  provided or if no session backend is currently holding the provided key.
+
+ALIASES
+  $ jamsocket connect
+
+EXAMPLES
+  $ jamsocket connect my-service
+
+  $ jamsocket connect my-service -k my-key
+
+  $ jamsocket connect my-service -t my-tag
+
+  $ jamsocket connect my-service -e SOME_ENV_VAR=foo -e ANOTHER_ENV_VAR=bar
+
+  $ jamsocket connect my-service -i 60
+
+  $ jamsocket connect my-service -l 300
+
+  $ jamsocket connect my-service --no-spawn
+
+  $ jamsocket connect my-service -u my-user -a '{"foo":"my-json-data"}'
 ```
 
 ## `jamsocket dev`
@@ -274,6 +332,59 @@ EXAMPLES
   $ jamsocket push my-service -f path/to/Dockerfile -c .
 
   $ jamsocket push my-service my-image -t my-tag
+```
+
+## `jamsocket service connect SERVICE`
+
+Gets a URL that can be used to connect to a session backend. Will spawn a new session backend if no key (aka lock) is provided or if no session backend is currently holding the provided key.
+
+```
+USAGE
+  $ jamsocket service connect [SERVICE] [-e <value>] [-t <value>] [-i <value>] [-l <value>] [-k <value>] [-u <value>]
+    [-a <value>] [--spawn]
+
+ARGUMENTS
+  SERVICE  Name of service to spawn.
+
+FLAGS
+  -a, --auth=<value>                    Optional serialized JSON to be passed to a session backend when connecting with
+                                        the returned URL/connection string.
+  -e, --env=<value>...                  optional environment variables to pass to the container
+  -i, --max-idle-seconds=<value>        The max time in seconds a session backend should wait after last connection is
+                                        closed before shutting down container (default is 300)
+  -k, --key=<value>                     If provided, fetches the session backend currently holding the given key
+                                        (formerly known as a "lock"). If no session backend holds the key, or if a key
+                                        is not provided, a new session backend will be spawned.
+  -l, --lifetime-limit-seconds=<value>  The max time in seconds the session backend should be allowed to run.
+  -t, --tag=<value>                     An optional image tag or image digest to use when spawning a backend.
+  -u, --user=<value>                    Optional username to be associated with the URL/connection string returned by
+                                        the connect command.
+  --[no-]spawn                          Whether to spawn a new session backend if no session backend is currently
+                                        holding the provided key.
+
+DESCRIPTION
+  Gets a URL that can be used to connect to a session backend. Will spawn a new session backend if no key (aka lock) is
+  provided or if no session backend is currently holding the provided key.
+
+ALIASES
+  $ jamsocket connect
+
+EXAMPLES
+  $ jamsocket service connect my-service
+
+  $ jamsocket service connect my-service -k my-key
+
+  $ jamsocket service connect my-service -t my-tag
+
+  $ jamsocket service connect my-service -e SOME_ENV_VAR=foo -e ANOTHER_ENV_VAR=bar
+
+  $ jamsocket service connect my-service -i 60
+
+  $ jamsocket service connect my-service -l 300
+
+  $ jamsocket service connect my-service --no-spawn
+
+  $ jamsocket service connect my-service -u my-user -a '{"foo":"my-json-data"}'
 ```
 
 ## `jamsocket service create NAME`
@@ -453,7 +564,10 @@ Terminates one or more backends given the backend name(s).
 
 ```
 USAGE
-  $ jamsocket terminate [BACKENDS]
+  $ jamsocket terminate [BACKENDS] [-f]
+
+FLAGS
+  -f, --force  whether to force the backend to hard terminate (defaults to false)
 
 DESCRIPTION
   Terminates one or more backends given the backend name(s).

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -286,8 +286,12 @@ export class JamsocketApi {
   private async makeRequest<T>(endpoint: string, method: HttpMethod, body?: any, headers?: Headers, config?: JamsocketConfig): Promise<T> {
     const url = `${this.apiBase}${endpoint}`
     const user = config?.getUserEmail() ?? null
+    const account = config?.getAccount() ?? null
     if (user) {
       headers = { ...headers, 'X-Jamsocket-User': user }
+    }
+    if (account) {
+      headers = { ...headers, 'X-Jamsocket-Account': account }
     }
     const response = await request(url, body || null, { ...this.options, method, headers })
 
@@ -340,8 +344,12 @@ export class JamsocketApi {
   private makeStreamRequest(endpoint: string, headers: Headers | null, callback: (line: string) => void, config?: JamsocketConfig): EventStreamReturn {
     const url = `${this.apiBase}${endpoint}`
     const user = config?.getUserEmail() ?? null
+    const account = config?.getAccount() ?? null
     if (user) {
       headers = { ...headers, 'X-Jamsocket-User': user }
+    }
+    if (account) {
+      headers = { ...headers, 'X-Jamsocket-Account': account }
     }
     return eventStream(url, {
       ...this.options,

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -402,6 +402,12 @@ export class JamsocketApi {
     return this.makeAuthenticatedRequest<SpawnResult>(url, HttpMethod.Post, config, body)
   }
 
+  public connect(accountName: string, serviceName: string, serviceEnvironment: string | null, config: JamsocketConfig, body?: JamsocketConnectRequestBody): Promise<JamsocketConnectResponse> {
+    const service = serviceEnvironment ? `${serviceName}/${serviceEnvironment}` : serviceName
+    const url = `/v2/service/${accountName}/${service}/connect`
+    return this.makeAuthenticatedRequest<JamsocketConnectResponse>(url, HttpMethod.Post, config, body)
+  }
+
   public listRunningBackends(accountName: string, config: JamsocketConfig): Promise<RunningBackendsResult> {
     const url = `/v2/account/${accountName}/backends`
     return this.makeAuthenticatedRequest<RunningBackendsResult>(url, HttpMethod.Get, config)

--- a/cli/src/commands/backend/list.ts
+++ b/cli/src/commands/backend/list.ts
@@ -37,10 +37,10 @@ export default class List extends Command {
             '-'
         },
       },
-      lock: {
-        header: 'Lock',
+      key: {
+        header: 'Key (aka Lock)',
         get: row => {
-          return row.lock ? row.lock : ''
+          return row.key ? row.key : ''
         },
       },
     }, {

--- a/cli/src/commands/backend/terminate.ts
+++ b/cli/src/commands/backend/terminate.ts
@@ -1,4 +1,4 @@
-import { Command } from '@oclif/core'
+import { Command, Flags } from '@oclif/core'
 import { Jamsocket } from '../../jamsocket'
 import { lightMagenta } from '../../formatting'
 
@@ -12,15 +12,19 @@ export default class Terminate extends Command {
   ]
 
   static args = [{ name: 'backends', required: true }]
+  static flags = {
+    force: Flags.boolean({ char: 'f', description: 'whether to force the backend to hard terminate (defaults to false)' }),
+  }
 
   public async run(): Promise<void> {
     // it's not possible to have a multiple values for the same argument, so this is the workaround
     const backends = [...this.argv]
+    const { flags } = await this.parse(Terminate)
     const jamsocket = Jamsocket.fromEnvironment()
 
     for (const backend of backends) {
       try {
-        await jamsocket.terminate(backend)
+        await jamsocket.terminate(backend, flags.force)
       } catch {
         this.warn(`Failed to request termination for backend: ${lightMagenta(backend)}. Skipping...`)
         continue

--- a/cli/src/commands/service/connect.ts
+++ b/cli/src/commands/service/connect.ts
@@ -1,0 +1,112 @@
+import { Command, Flags } from '@oclif/core'
+import chalk from 'chalk'
+import { Jamsocket } from '../../jamsocket'
+import * as customFlags from '../../flags'
+import { blue, lightBlue, lightGreen } from '../../formatting'
+import { JamsocketConnectRequestBody } from '../../api'
+
+export default class Spawn extends Command {
+  static aliases = ['connect']
+
+  static description = 'Gets a URL that can be used to connect to a session backend. Will spawn a new session backend if no key (aka lock) is provided or if no session backend is currently holding the provided key.'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> my-service',
+    '<%= config.bin %> <%= command.id %> my-service -k my-key',
+    '<%= config.bin %> <%= command.id %> my-service -t my-tag',
+    '<%= config.bin %> <%= command.id %> my-service -e SOME_ENV_VAR=foo -e ANOTHER_ENV_VAR=bar',
+    '<%= config.bin %> <%= command.id %> my-service -i 60',
+    '<%= config.bin %> <%= command.id %> my-service -l 300',
+    '<%= config.bin %> <%= command.id %> my-service --no-spawn',
+    '<%= config.bin %> <%= command.id %> my-service -u my-user -a \'{"foo":"my-json-data"}\'',
+  ]
+
+  static flags = {
+    // passing { multiple: true } here due to a bug: https://github.com/oclif/core/pull/414
+    env: customFlags.env({ multiple: true }),
+    tag: Flags.string({ char: 't', description: 'An optional image tag or image digest to use when spawning a backend.' }),
+    'max-idle-seconds': Flags.integer({ char: 'i', description: 'The max time in seconds a session backend should wait after last connection is closed before shutting down container (default is 300)' }),
+    'lifetime-limit-seconds': Flags.integer({ char: 'l', description: 'The max time in seconds the session backend should be allowed to run.' }),
+    key: Flags.string({ char: 'k', description: 'If provided, fetches the session backend currently holding the given key (formerly known as a "lock"). If no session backend holds the key, or if a key is not provided, a new session backend will be spawned.' }),
+    user: Flags.string({ char: 'u', description: 'Optional username to be associated with the URL/connection string returned by the connect command.' }),
+    auth: Flags.string({ char: 'a', description: 'Optional serialized JSON to be passed to a session backend when connecting with the returned URL/connection string.' }),
+    spawn: Flags.boolean({ default: true, allowNo: true, description: 'Whether to spawn a new session backend if no session backend is currently holding the provided key.' }),
+  }
+
+  static args = [
+    { name: 'service', required: true, description: 'Name of service to spawn.' },
+  ]
+
+  public async run(): Promise<void> {
+    const { args, flags } = await this.parse(Spawn)
+
+    const env = flags.env ? Object.fromEntries(flags.env) : undefined
+
+    const parts = args.service.split('/')
+    if (parts.length > 2 || parts[0] === '' || parts[1] === '') {
+      this.error(`Invalid service/environment name: ${args.service}`)
+    }
+
+    const service = parts[0]
+    const environment = parts[1]
+
+    let auth: Record<string, any> | undefined
+    if (flags.auth) {
+      try {
+        auth = JSON.parse(flags.auth)
+      } catch {
+        this.error('Failed to parse JSON provided to --auth flag.')
+      }
+    }
+
+    const connectReqBody: JamsocketConnectRequestBody = {
+      key: flags.key,
+      user: flags.user,
+      auth,
+    }
+
+    if (flags.spawn === false) {
+      if (connectReqBody.key === undefined) {
+        this.error('The --no-spawn flag requires a key to be provided.')
+      }
+      if (flags.tag) {
+        this.warn('Ignoring --tag flag because --no-spawn flag was provided.')
+      }
+      if (flags['max-idle-seconds']) {
+        this.warn('Ignoring --max-idle-seconds flag because --no-spawn flag was provided.')
+      }
+      if (flags['lifetime-limit-seconds']) {
+        this.warn('Ignoring --lifetime-limit-seconds flag because --no-spawn flag was provided.')
+      }
+      if (flags.env) {
+        this.warn('Ignoring --env flag because --no-spawn flag was provided.')
+      }
+      connectReqBody.spawn = false
+    } else {
+      connectReqBody.spawn = {
+        tag: flags.tag,
+        executable: {
+          env,
+        },
+        lifetime_limit_seconds: flags['lifetime-limit-seconds'],
+        max_idle_seconds: flags['max-idle-seconds'],
+      }
+    }
+
+    const jamsocket = Jamsocket.fromEnvironment()
+    const responseBody = await jamsocket.connect(service, environment, connectReqBody)
+
+    const appBaseUrl = jamsocket.api.getAppBaseUrl()
+
+    this.log(lightBlue('Backend spawned!'))
+    this.log(chalk.bold`backend id:     `, blue(responseBody.backend_id))
+    this.log(chalk.bold`backend status: `, blue(responseBody.status ?? '-'))
+    this.log(chalk.bold`backend url:    `, blue(responseBody.url))
+    this.log(chalk.bold`status url:     `, blue(responseBody.status_url))
+    this.log(chalk.bold`ready url:      `, blue(responseBody.ready_url))
+    if (flags.key) {
+      this.log(chalk.bold`spawned:        `, blue(responseBody.spawned.toString()))
+    }
+    this.log(chalk.bold`dashboard:      `, lightGreen(`${appBaseUrl}/backend/${responseBody.backend_id}`))
+  }
+}

--- a/cli/src/commands/service/delete.ts
+++ b/cli/src/commands/service/delete.ts
@@ -19,7 +19,6 @@ export default class Create extends Command {
     const jamsocket = Jamsocket.fromEnvironment()
     const serviceInfo = await jamsocket.serviceInfo(args.name)
 
-    const spawnTokenCount = serviceInfo.spawn_tokens_count
     const lastImgUpload = serviceInfo.last_image_upload_time ? formatDistanceToNow(new Date(serviceInfo.last_image_upload_time)) : null
     const lastSpawn = serviceInfo.last_spawned_at ? formatDistanceToNow(new Date(serviceInfo.last_spawned_at)) : null
 
@@ -27,7 +26,6 @@ export default class Create extends Command {
       'The service',
       lightBlue(serviceInfo.name),
       lastImgUpload === null ? ('has ' + lightMagenta('no container images') + ',') : ('had a ' + lightMagenta(`container image pushed to it ${lastImgUpload} ago`) + ','),
-      spawnTokenCount === 0 ? '' : ('has ' + lightMagenta(`${spawnTokenCount} spawn tokens`) + ','),
       lastSpawn === null ? ('and has ' + lightMagenta('never been spawned') + '.') : ('and was ' + lightMagenta(`last spawned ${lastSpawn} ago`) + '.'),
     ].filter(Boolean)
 

--- a/cli/src/jamsocket.ts
+++ b/cli/src/jamsocket.ts
@@ -1,5 +1,5 @@
 import { JamsocketApi, BackendInfoResult, RunningBackendsResult, SpawnRequestBody, SpawnResult, PlaneV2StatusMessage, TerminateResult } from './api'
-import type { ServiceCreateResult, ServiceListResult, ServiceInfoResult, ServiceDeleteResult, ServiceImagesResult, EnvironmentUpdateResult } from './api'
+import type { ServiceCreateResult, ServiceListResult, ServiceInfoResult, ServiceDeleteResult, ServiceImagesResult, EnvironmentUpdateResult, JamsocketConnectRequestBody, JamsocketConnectResponse } from './api'
 import { JamsocketConfig } from './jamsocket-config'
 import { tag as dockerTag, push as dockerPush } from './docker'
 import type { EventStreamReturn } from './request'
@@ -56,6 +56,11 @@ export class Jamsocket {
     }
 
     return this.api.spawn(config.getAccount(), service, config, body)
+  }
+
+  public connect(service: string, serviceEnvironment: string | null, body?: JamsocketConnectRequestBody): Promise<JamsocketConnectResponse> {
+    const config = this.expectAuthorized()
+    return this.api.connect(config.getAccount(), service, serviceEnvironment, config, body)
   }
 
   public terminate(backend: string, hard: boolean): Promise<TerminateResult> {

--- a/cli/src/jamsocket.ts
+++ b/cli/src/jamsocket.ts
@@ -1,4 +1,4 @@
-import { JamsocketApi, BackendInfoResult, RunningBackendsResult, SpawnRequestBody, SpawnResult, StatusMessage, TerminateResult } from './api'
+import { JamsocketApi, BackendInfoResult, RunningBackendsResult, SpawnRequestBody, SpawnResult, PlaneV2StatusMessage, TerminateResult } from './api'
 import type { ServiceCreateResult, ServiceListResult, ServiceInfoResult, ServiceDeleteResult, ServiceImagesResult, EnvironmentUpdateResult } from './api'
 import { JamsocketConfig } from './jamsocket-config'
 import { tag as dockerTag, push as dockerPush } from './docker'
@@ -58,9 +58,9 @@ export class Jamsocket {
     return this.api.spawn(config.getAccount(), service, config, body)
   }
 
-  public terminate(backend: string): Promise<TerminateResult> {
+  public terminate(backend: string, hard: boolean): Promise<TerminateResult> {
     const config = this.expectAuthorized()
-    return this.api.terminate(backend, config)
+    return this.api.terminate(backend, hard, config)
   }
 
   public backendInfo(backend: string): Promise<BackendInfoResult> {
@@ -116,11 +116,11 @@ export class Jamsocket {
     return this.api.streamMetrics(backend, config, callback)
   }
 
-  public streamStatus(backend: string, callback: (v: StatusMessage) => void, config?: JamsocketConfig): EventStreamReturn {
+  public streamStatus(backend: string, callback: (v: PlaneV2StatusMessage) => void, config?: JamsocketConfig): EventStreamReturn {
     return this.api.streamStatus(backend, callback, config)
   }
 
-  public status(backend: string, config?: JamsocketConfig): Promise<StatusMessage> {
+  public status(backend: string, config?: JamsocketConfig): Promise<PlaneV2StatusMessage> {
     return this.api.status(backend, config)
   }
 }


### PR DESCRIPTION
Recommended to review commit-by-commit. This PR does four things:

1. Adds v2 endpoints to the dev server so users can troubleshoot switching to v2 endpoints (and statuses) locally
2. Updates the v2 endpoints used in the commands to support v2 statuses (and other various changes that have come with the v2 endpoints)
3. Adds a connect command that uses the connect endpoint and most of its new functionality
4. Adds a `X-Jamsocket-Account` header to requests