### PR TITLE
updates per platform changes

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -32,26 +32,24 @@ If you want to use the Jamsocket CLI from an automated environment (e.g. a CI/CD
 * [`jamsocket logs BACKEND`](#jamsocket-logs-backend)
 * [`jamsocket push SERVICE [IMAGE]`](#jamsocket-push-service-image)
 * [`jamsocket service connect SERVICE`](#jamsocket-service-connect-service)
-* [`jamsocket service create NAME`](#jamsocket-service-create-name)
-* [`jamsocket service delete NAME`](#jamsocket-service-delete-name)
+* [`jamsocket service create SERVICE`](#jamsocket-service-create-service)
+* [`jamsocket service delete SERVICE`](#jamsocket-service-delete-service)
 * [`jamsocket service images SERVICE`](#jamsocket-service-images-service)
-* [`jamsocket service info NAME`](#jamsocket-service-info-name)
+* [`jamsocket service info SERVICE`](#jamsocket-service-info-service)
 * [`jamsocket service list`](#jamsocket-service-list)
-* [`jamsocket service spawn SERVICE`](#jamsocket-service-spawn-service)
 * [`jamsocket service use-image SERVICE`](#jamsocket-service-use-image-service)
-* [`jamsocket spawn SERVICE`](#jamsocket-spawn-service)
 * [`jamsocket terminate BACKENDS`](#jamsocket-terminate-backends)
 
 ## `jamsocket backend info BACKEND`
 
-Retrieves information about a backend given its name.
+Retrieves information about a backend given a Backend ID.
 
 ```
 USAGE
   $ jamsocket backend info [BACKEND]
 
 DESCRIPTION
-  Retrieves information about a backend given its name.
+  Retrieves information about a backend given a Backend ID.
 
 EXAMPLES
   $ jamsocket backend info a8m32q
@@ -81,7 +79,7 @@ USAGE
   $ jamsocket backend logs [BACKEND]
 
 ARGUMENTS
-  BACKEND  The name of the backend, a random string of letters and numbers returned by the spawn command.
+  BACKEND  The backend ID, a random string of letters and numbers returned by the connect command.
 
 DESCRIPTION
   Stream logs from a running backend.
@@ -102,7 +100,7 @@ USAGE
   $ jamsocket backend metrics [BACKEND]
 
 ARGUMENTS
-  BACKEND  The name of the backend, a random string of letters and numbers returned by the spawn command.
+  BACKEND  The backend ID, a random string of letters and numbers returned by the connect command.
 
 DESCRIPTION
   Stream metrics from a running backend
@@ -113,7 +111,7 @@ EXAMPLES
 
 ## `jamsocket backend terminate BACKENDS`
 
-Terminates one or more backends given the backend name(s).
+Terminates one or more backends given the backend ID(s).
 
 ```
 USAGE
@@ -123,7 +121,7 @@ FLAGS
   -f, --force  whether to force the backend to hard terminate (defaults to false)
 
 DESCRIPTION
-  Terminates one or more backends given the backend name(s).
+  Terminates one or more backends given the backend ID(s).
 
 ALIASES
   $ jamsocket terminate
@@ -294,7 +292,7 @@ USAGE
   $ jamsocket logs [BACKEND]
 
 ARGUMENTS
-  BACKEND  The name of the backend, a random string of letters and numbers returned by the spawn command.
+  BACKEND  The backend ID, a random string of letters and numbers returned by the connect command.
 
 DESCRIPTION
   Stream logs from a running backend.
@@ -389,13 +387,13 @@ EXAMPLES
   $ jamsocket service connect my-service -u my-user -a '{"foo":"my-json-data"}'
 ```
 
-## `jamsocket service create NAME`
+## `jamsocket service create SERVICE`
 
 Creates a service
 
 ```
 USAGE
-  $ jamsocket service create [NAME]
+  $ jamsocket service create [SERVICE]
 
 DESCRIPTION
   Creates a service
@@ -404,13 +402,13 @@ EXAMPLES
   $ jamsocket service create my-service
 ```
 
-## `jamsocket service delete NAME`
+## `jamsocket service delete SERVICE`
 
 Deletes a service
 
 ```
 USAGE
-  $ jamsocket service delete [NAME]
+  $ jamsocket service delete [SERVICE]
 
 DESCRIPTION
   Deletes a service
@@ -437,13 +435,13 @@ EXAMPLES
   $ jamsocket service images my-service
 ```
 
-## `jamsocket service info NAME`
+## `jamsocket service info SERVICE`
 
 Gets some information about a service
 
 ```
 USAGE
-  $ jamsocket service info [NAME]
+  $ jamsocket service info [SERVICE]
 
 DESCRIPTION
   Gets some information about a service
@@ -467,102 +465,31 @@ EXAMPLES
   $ jamsocket service list
 ```
 
-## `jamsocket service spawn SERVICE`
-
-Spawns a session backend with the provided service/environment's docker image.
-
-```
-USAGE
-  $ jamsocket service spawn [SERVICE] [-e <value>] [-g <value>] [-l <value>]
-
-ARGUMENTS
-  SERVICE  Name of service/environment to spawn. (Providing the environment is optional if service only has one
-           environment, otherwise it is required)
-
-FLAGS
-  -e, --env=<value>...  optional environment variables to pass to the container
-  -g, --grace=<value>   optional grace period (in seconds) to wait after last connection is closed before shutting down
-                        container (default is 300)
-  -l, --lock=<value>    optional lock to spawn the service with
-
-DESCRIPTION
-  Spawns a session backend with the provided service/environment's docker image.
-
-ALIASES
-  $ jamsocket spawn
-
-EXAMPLES
-  $ jamsocket service spawn my-service
-
-  $ jamsocket service spawn my-service/prod
-
-  $ jamsocket service spawn my-service -e SOME_ENV_VAR=foo -e ANOTHER_ENV_VAR=bar
-
-  $ jamsocket service spawn my-service -g 60
-```
-
 ## `jamsocket service use-image SERVICE`
 
-Sets the image tag or digest to use when spawning a service/environment
+Sets the image tag or digest to use when spawning a service
 
 ```
 USAGE
   $ jamsocket service use-image [SERVICE] -i <value>
 
 ARGUMENTS
-  SERVICE  Name of service/environment whose image should be updated. If only a service is provided, the "default"
-           environment is used.
+  SERVICE  Name of service whose spawning image should be updated.
 
 FLAGS
-  -i, --image=<value>  (required) image tag or digest for the service/environment to use (Run `jamsocket images` for a
-                       list of images you can use.)
+  -i, --image=<value>  (required) image tag or digest for the service to use (Run `jamsocket images` for a list of
+                       images you can use.)
 
 DESCRIPTION
-  Sets the image tag or digest to use when spawning a service/environment
+  Sets the image tag or digest to use when spawning a service
 
 EXAMPLES
   $ jamsocket service use-image my-service -i latest
-
-  $ jamsocket service use-image my-service/prod -i sha256:1234abcd
-```
-
-## `jamsocket spawn SERVICE`
-
-Spawns a session backend with the provided service/environment's docker image.
-
-```
-USAGE
-  $ jamsocket spawn [SERVICE] [-e <value>] [-g <value>] [-l <value>]
-
-ARGUMENTS
-  SERVICE  Name of service/environment to spawn. (Providing the environment is optional if service only has one
-           environment, otherwise it is required)
-
-FLAGS
-  -e, --env=<value>...  optional environment variables to pass to the container
-  -g, --grace=<value>   optional grace period (in seconds) to wait after last connection is closed before shutting down
-                        container (default is 300)
-  -l, --lock=<value>    optional lock to spawn the service with
-
-DESCRIPTION
-  Spawns a session backend with the provided service/environment's docker image.
-
-ALIASES
-  $ jamsocket spawn
-
-EXAMPLES
-  $ jamsocket spawn my-service
-
-  $ jamsocket spawn my-service/prod
-
-  $ jamsocket spawn my-service -e SOME_ENV_VAR=foo -e ANOTHER_ENV_VAR=bar
-
-  $ jamsocket spawn my-service -g 60
 ```
 
 ## `jamsocket terminate BACKENDS`
 
-Terminates one or more backends given the backend name(s).
+Terminates one or more backends given the backend ID(s).
 
 ```
 USAGE
@@ -572,7 +499,7 @@ FLAGS
   -f, --force  whether to force the backend to hard terminate (defaults to false)
 
 DESCRIPTION
-  Terminates one or more backends given the backend name(s).
+  Terminates one or more backends given the backend ID(s).
 
 ALIASES
   $ jamsocket terminate

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -110,7 +110,7 @@ export type PublicV2State =
 
 // these are v2 states that are returned from authenticated endpoints
 // they are the same as the public v2 statuses except they include the
-// exit_code field instead of exit_error
+// exit_code field instead of exit_error and a last_status field
 export type V2State =
   | { status: 'scheduled'; time: string }
   | { status: 'loading'; time: string }
@@ -125,6 +125,7 @@ export type V2State =
       termination_reason?: PlaneTerminationReason | null
       termination_kind?: PlaneTerminationKind | null
       exit_code?: number | null
+      last_status: V2Status
     }
 
 export type UpdateEnvironmentBody = {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -124,8 +124,7 @@ export type PlaneV2State =
     }
 
 export type UpdateEnvironmentBody = {
-  name?: string
-  image_tag?: string
+  image_tag: string
 }
 
 export interface ServiceImageResult {
@@ -488,11 +487,16 @@ export class JamsocketApi {
   public updateEnvironment(
     accountName: string,
     service: string,
-    environment: string,
+    environment: string | null,
     config: JamsocketConfig,
     body: UpdateEnvironmentBody,
   ): Promise<EnvironmentUpdateResult> {
-    const url = `/v2/service-env/${accountName}/${service}/${environment}/update`
+    let url = `/v2/service/${accountName}/${service}`
+    if (environment) {
+      url += `/${environment}`
+    }
+    url += '/update'
+
     return this.makeAuthenticatedRequest<EnvironmentUpdateResult>(
       url,
       HttpMethod.Post,

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -83,43 +83,47 @@ export type JamsocketConnectResponse = {
   ready_url: string
 }
 
-// these are public messages that come over the status and status/stream endpoints
+export type PlaneTerminationKind = 'soft' | 'hard'
 export type PlaneTerminationReason =
   | 'swept'
   | 'external'
   | 'key_expired'
   | 'lost'
   | 'startup_timeout'
-export type PlaneTerminationKind = 'soft' | 'hard'
-export type PlaneV2StatusMessage =
-  | { status: 'scheduled'; time: number }
-  | { status: 'loading'; time: number }
-  | { status: 'starting'; time: number }
-  | { status: 'waiting'; time: number }
-  | { status: 'ready'; time: number }
-  | { status: 'terminating'; time: number; termination_reason: PlaneTerminationReason }
-  | { status: 'hard-terminating'; time: number; termination_reason: PlaneTerminationReason }
+
+// these are public messages that come over the status and status/stream endpoints
+export type PublicV2State =
+  | { status: 'scheduled'; time: string }
+  | { status: 'loading'; time: string }
+  | { status: 'starting'; time: string }
+  | { status: 'waiting'; time: string }
+  | { status: 'ready'; time: string }
+  | { status: 'terminating'; time: string; termination_reason: PlaneTerminationReason }
+  | { status: 'hard-terminating'; time: string; termination_reason: PlaneTerminationReason }
   | {
       status: 'terminated'
-      time: number
-      termination_reason?: PlaneTerminationReason
-      termination_kind?: PlaneTerminationKind
-      exit_error?: boolean
+      time: string
+      termination_reason?: PlaneTerminationReason | null
+      termination_kind?: PlaneTerminationKind | null
+      exit_error?: boolean | null
     }
 
-export type PlaneV2State =
-  | { status: 'scheduled' }
-  | { status: 'loading' }
-  | { status: 'starting' }
-  | { status: 'waiting'; address?: string }
-  | { status: 'ready'; address?: string }
-  | { status: 'terminating'; last_status: V2Status; reason: PlaneTerminationReason }
-  | { status: 'hard-terminating'; last_status: V2Status; reason: PlaneTerminationReason }
+// these are v2 states that are returned from authenticated endpoints
+// they are the same as the public v2 statuses except they include the
+// exit_code field instead of exit_error
+export type V2State =
+  | { status: 'scheduled'; time: string }
+  | { status: 'loading'; time: string }
+  | { status: 'starting'; time: string }
+  | { status: 'waiting'; time: string }
+  | { status: 'ready'; time: string }
+  | { status: 'terminating'; time: string; termination_reason: PlaneTerminationReason }
+  | { status: 'hard-terminating'; time: string; termination_reason: PlaneTerminationReason }
   | {
       status: 'terminated'
-      last_status: V2Status
-      reason: PlaneTerminationReason
-      termination: PlaneTerminationKind
+      time: string
+      termination_reason?: PlaneTerminationReason | null
+      termination_kind?: PlaneTerminationKind | null
       exit_code?: number | null
     }
 
@@ -188,13 +192,12 @@ export interface SpawnResult {
 }
 
 export type BackendWithStatus = {
-  name: string
+  id: string
   created_at: string
   service_name: string
   cluster_name: string
   account_name: string
-  status?: V2Status
-  status_timestamp?: string
+  status?: V2State
   key?: string
 }
 
@@ -206,18 +209,13 @@ export interface TerminateResult {
   status: 'ok'
 }
 
-export interface BackendV2Status {
-  value: PlaneV2State
-  timestamp: string
-}
-
 export interface BackendInfoResult {
-  name: string
+  id: string
   created_at: string
   service_name: string
   cluster_name: string
   account_name: string
-  statuses: BackendV2Status[]
+  statuses: V2State[]
   image_digest: string
   key?: string | null
   environment_name?: string | null
@@ -569,7 +567,7 @@ export class JamsocketApi {
 
   public streamStatus(
     backend: string,
-    callback: (statusMessage: PlaneV2StatusMessage) => void,
+    callback: (statusMessage: PublicV2State) => void,
     config?: JamsocketConfig,
   ): EventStreamReturn {
     const url = `/v2/backend/${backend}/status/stream`
@@ -580,9 +578,9 @@ export class JamsocketApi {
     return this.makeStreamRequest(url, null, wrappedCallback, config)
   }
 
-  public async status(backend: string, config?: JamsocketConfig): Promise<PlaneV2StatusMessage> {
+  public async status(backend: string, config?: JamsocketConfig): Promise<PublicV2State> {
     const url = `/v2/backend/${backend}/status`
-    return this.makeRequest<PlaneV2StatusMessage>(url, HttpMethod.Get, undefined, undefined, config)
+    return this.makeRequest<PublicV2State>(url, HttpMethod.Get, undefined, undefined, config)
   }
 
   public async terminate(

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -447,7 +447,7 @@ export class JamsocketApi {
     serviceName: string,
     config: JamsocketConfig,
   ): Promise<ServiceImageResult> {
-    const url = `/v2/service/${accountName}/${serviceName}/image-name`
+    const url = `/service/${accountName}/${serviceName}/image-name`
     return this.makeAuthenticatedRequest<ServiceImageResult>(url, HttpMethod.Get, config)
   }
 

--- a/cli/src/commands/backend/info.ts
+++ b/cli/src/commands/backend/info.ts
@@ -4,7 +4,7 @@ import { Jamsocket } from '../../jamsocket'
 import { formatDistanceToNow } from 'date-fns'
 import prettyBytes from '../../lib/pretty-bytes'
 import { blue, lightBlue, lightMagenta, lightGreen } from '../../lib/formatting'
-import { PlaneV2State } from '../../api'
+import { V2State } from '../../api'
 
 export default class Info extends Command {
   static description = 'Retrieves information about a backend given a Backend ID.'
@@ -20,7 +20,7 @@ export default class Info extends Command {
 
     const appBaseUrl = jamsocket.api.getAppBaseUrl()
 
-    this.log(chalk.bold`Info for backend: ${lightMagenta(info.name)}`)
+    this.log(chalk.bold`Info for backend: ${lightMagenta(info.id)}`)
     this.log(
       `created:      ${blue(info.created_at)} (${formatDistanceToNow(new Date(info.created_at))} ago)`,
     )
@@ -32,23 +32,21 @@ export default class Info extends Command {
     if (info.environment_name && info.environment_name !== 'default')
       this.log(`environment:  ${blue(info.environment_name)}`)
     if (info.max_mem_bytes) this.log(`mem usage:    ${blue(prettyBytes(info.max_mem_bytes))}`)
-    this.log(`dashboard:    ${lightGreen(`${appBaseUrl}/backend/${info.name}`)}`)
+    this.log(`dashboard:    ${lightGreen(`${appBaseUrl}/backend/${info.id}`)}`)
     this.log()
     this.log(chalk.bold`Statuses:`)
     if (info.statuses.length === 0) {
       this.log('backend has no statuses')
     } else {
-      info.statuses.sort((a, b) => (a.timestamp > b.timestamp ? 1 : -1))
+      info.statuses.sort((a, b) => (a.time > b.time ? 1 : -1))
       for (const status of info.statuses) {
-        this.log(
-          `${status.timestamp}  ${lightBlue(status.value.status)} ${formatStatusMeta(status.value)}`,
-        )
+        this.log(`${status.time}  ${lightBlue(status.status)} ${formatStatusMeta(status)}`)
       }
     }
   }
 }
 
-function formatStatusMeta(value: PlaneV2State): string {
+function formatStatusMeta(value: V2State): string {
   const meta: string[] = []
   if (
     value.status === 'scheduled' ||
@@ -60,10 +58,10 @@ function formatStatusMeta(value: PlaneV2State): string {
     return ''
   }
 
-  meta.push(`reason: ${value.reason}`)
+  meta.push(`reason: ${value.termination_reason}`)
 
   if (value.status === 'terminated') {
-    meta.push(`kind: ${value.termination}`, `exit code: ${value.exit_code ?? '-'}`)
+    meta.push(`kind: ${value.termination_kind}`, `exit code: ${value.exit_code ?? '-'}`)
   }
 
   return `(${meta.join(', ')})`

--- a/cli/src/commands/backend/info.ts
+++ b/cli/src/commands/backend/info.ts
@@ -7,7 +7,7 @@ import { blue, lightBlue, lightMagenta, lightGreen } from '../../lib/formatting'
 import { PlaneV2State } from '../../api'
 
 export default class Info extends Command {
-  static description = 'Retrieves information about a backend given its name.'
+  static description = 'Retrieves information about a backend given a Backend ID.'
   static examples = ['<%= config.bin %> <%= command.id %> a8m32q']
 
   static args = [{ name: 'backend', required: true }]
@@ -29,7 +29,8 @@ export default class Info extends Command {
     this.log(`cluster:      ${blue(info.cluster_name)}`)
     this.log(`image digest: ${blue(info.image_digest)}`)
     if (info.key) this.log(`key:          ${blue(info.key)}`)
-    if (info.environment_name) this.log(`environment:  ${blue(info.environment_name)}`)
+    if (info.environment_name && info.environment_name !== 'default')
+      this.log(`environment:  ${blue(info.environment_name)}`)
     if (info.max_mem_bytes) this.log(`mem usage:    ${blue(prettyBytes(info.max_mem_bytes))}`)
     this.log(`dashboard:    ${lightGreen(`${appBaseUrl}/backend/${info.name}`)}`)
     this.log()

--- a/cli/src/commands/backend/list.ts
+++ b/cli/src/commands/backend/list.ts
@@ -22,7 +22,7 @@ export default class List extends Command {
     CliUx.ux.table<BackendWithStatus>(
       responseBody.running_backends,
       {
-        name: { header: 'ID' },
+        id: { header: 'ID' },
         created_at: {
           header: 'Created',
           get: (row) => `${formatDistanceToNow(new Date(row.created_at))} ago`,
@@ -33,7 +33,7 @@ export default class List extends Command {
           header: 'Status',
           get: (row) => {
             return row.status
-              ? `${row.status} (${formatDistanceToNow(new Date(row.status_timestamp!))})`
+              ? `${row.status.status} (${formatDistanceToNow(new Date(row.status.time))})`
               : '-'
           },
         },

--- a/cli/src/commands/backend/list.ts
+++ b/cli/src/commands/backend/list.ts
@@ -22,7 +22,7 @@ export default class List extends Command {
     CliUx.ux.table<BackendWithStatus>(
       responseBody.running_backends,
       {
-        name: { header: 'Name' },
+        name: { header: 'ID' },
         created_at: {
           header: 'Created',
           get: (row) => `${formatDistanceToNow(new Date(row.created_at))} ago`,

--- a/cli/src/commands/backend/logs.ts
+++ b/cli/src/commands/backend/logs.ts
@@ -11,7 +11,7 @@ export default class Logs extends Command {
     {
       name: 'backend',
       description:
-        'The name of the backend, a random string of letters and numbers returned by the spawn command.',
+        'The backend ID, a random string of letters and numbers returned by the connect command.',
       required: true,
     },
   ]

--- a/cli/src/commands/backend/metrics.ts
+++ b/cli/src/commands/backend/metrics.ts
@@ -27,7 +27,7 @@ export default class Metrics extends Command {
     {
       name: 'backend',
       description:
-        'The name of the backend, a random string of letters and numbers returned by the spawn command.',
+        'The backend ID, a random string of letters and numbers returned by the connect command.',
       required: true,
     },
   ]

--- a/cli/src/commands/backend/terminate.ts
+++ b/cli/src/commands/backend/terminate.ts
@@ -1,6 +1,7 @@
 import { Command, Flags } from '@oclif/core'
 import { Jamsocket } from '../../jamsocket'
 import { lightMagenta } from '../../lib/formatting'
+import { HTTPError } from '../../api'
 
 export default class Terminate extends Command {
   static description = 'Terminates one or more backends given the backend ID(s).'
@@ -26,8 +27,13 @@ export default class Terminate extends Command {
     for (const backend of backends) {
       try {
         await jamsocket.terminate(backend, flags.force)
-      } catch {
-        this.warn(
+      } catch (e) {
+        if (e instanceof HTTPError && e.code === 'BackendNotRunning') {
+          this.warn(`Backend ${lightMagenta(backend)} has already terminated. Skipping...`)
+          continue
+        }
+
+        this.error(
           `Failed to request termination for backend: ${lightMagenta(backend)}. Skipping...`,
         )
         continue

--- a/cli/src/commands/backend/terminate.ts
+++ b/cli/src/commands/backend/terminate.ts
@@ -3,7 +3,7 @@ import { Jamsocket } from '../../jamsocket'
 import { lightMagenta } from '../../lib/formatting'
 
 export default class Terminate extends Command {
-  static description = 'Terminates one or more backends given the backend name(s).'
+  static description = 'Terminates one or more backends given the backend ID(s).'
   // we turn off strict mode so that we can accept multiple values for the same argument
   static strict = false
   static aliases = ['terminate']

--- a/cli/src/commands/service/connect.ts
+++ b/cli/src/commands/service/connect.ts
@@ -70,7 +70,7 @@ export default class Spawn extends Command {
 
     const parts = args.service.split('/')
     if (parts.length > 2 || parts[0] === '' || parts[1] === '') {
-      this.error(`Invalid service/environment name: ${args.service}`)
+      this.error(`Invalid service name: ${args.service}`)
     }
 
     const service = parts[0]

--- a/cli/src/commands/service/create.ts
+++ b/cli/src/commands/service/create.ts
@@ -7,14 +7,14 @@ export default class Create extends Command {
 
   static examples = ['<%= config.bin %> <%= command.id %> my-service']
 
-  static args = [{ name: 'name', required: true }]
+  static args = [{ name: 'service', required: true }]
 
   public async run(): Promise<void> {
     const { args } = await this.parse(Create)
 
     const jamsocket = Jamsocket.fromEnvironment()
-    await jamsocket.serviceCreate(args.name)
+    await jamsocket.serviceCreate(args.service)
 
-    this.log(`Created service: ${lightMagenta(args.name)}`)
+    this.log(`Created service: ${lightMagenta(args.service)}`)
   }
 }

--- a/cli/src/commands/service/delete.ts
+++ b/cli/src/commands/service/delete.ts
@@ -9,13 +9,13 @@ export default class Create extends Command {
 
   static examples = ['<%= config.bin %> <%= command.id %> my-service']
 
-  static args = [{ name: 'name', required: true }]
+  static args = [{ name: 'service', required: true }]
 
   public async run(): Promise<void> {
     const { args } = await this.parse(Create)
 
     const jamsocket = Jamsocket.fromEnvironment()
-    const serviceInfo = await jamsocket.serviceInfo(args.name)
+    const serviceInfo = await jamsocket.serviceInfo(args.service)
 
     const lastImgUpload = serviceInfo.last_image_upload_time
       ? formatDistanceToNow(new Date(serviceInfo.last_image_upload_time))
@@ -67,8 +67,8 @@ export default class Create extends Command {
       return
     }
 
-    await jamsocket.serviceDelete(args.name)
+    await jamsocket.serviceDelete(args.service)
 
-    this.log(`Deleted service: ${args.name}`)
+    this.log(`Deleted service: ${args.service}`)
   }
 }

--- a/cli/src/commands/service/info.ts
+++ b/cli/src/commands/service/info.ts
@@ -9,13 +9,13 @@ export default class Create extends Command {
 
   static examples = ['<%= config.bin %> <%= command.id %> my-service']
 
-  static args = [{ name: 'name', required: true }]
+  static args = [{ name: 'service', required: true }]
 
   public async run(): Promise<void> {
     const { args } = await this.parse(Create)
 
     const jamsocket = Jamsocket.fromEnvironment()
-    const info = await jamsocket.serviceInfo(args.name)
+    const info = await jamsocket.serviceInfo(args.service)
 
     const appBaseUrl = jamsocket.api.getAppBaseUrl()
 

--- a/cli/src/commands/service/spawn.ts
+++ b/cli/src/commands/service/spawn.ts
@@ -6,9 +6,10 @@ import { blue, lightBlue, lightGreen } from '../../lib/formatting'
 
 export default class Spawn extends Command {
   static aliases = ['spawn']
+  static hidden = true
 
   static description =
-    "Spawns a session backend with the provided service/environment's docker image."
+    "Spawns a session backend for the provided service. (NOTE: this command is deprecated, please use the 'connect' command instead.)"
 
   static examples = [
     '<%= config.bin %> <%= command.id %> my-service',
@@ -25,15 +26,14 @@ export default class Spawn extends Command {
       description:
         'optional grace period (in seconds) to wait after last connection is closed before shutting down container (default is 300)',
     }),
-    lock: Flags.string({ char: 'l', description: 'optional lock to spawn the service with' }),
+    lock: Flags.string({ char: 'l', description: 'optional lock/key to spawn the service with' }),
   }
 
   static args = [
     {
       name: 'service',
       required: true,
-      description:
-        'Name of service/environment to spawn. (Providing the environment is optional if service only has one environment, otherwise it is required)',
+      description: 'Name of service to spawn.',
     },
   ]
 
@@ -44,7 +44,7 @@ export default class Spawn extends Command {
 
     const parts = args.service.split('/')
     if (parts.length > 2 || parts[0] === '' || parts[1] === '') {
-      this.error(`Invalid service/environment name: ${args.service}`)
+      this.error(`Invalid service name: ${args.service}`)
     }
 
     const service = parts[0]
@@ -56,7 +56,7 @@ export default class Spawn extends Command {
     const appBaseUrl = jamsocket.api.getAppBaseUrl()
 
     this.log(lightBlue('Backend spawned!'))
-    this.log(chalk.bold`backend name:   `, blue(responseBody.name))
+    this.log(chalk.bold`backend ID:     `, blue(responseBody.name))
     this.log(chalk.bold`backend status: `, blue(responseBody.status ?? '-'))
     this.log(chalk.bold`backend url:    `, blue(responseBody.url))
     this.log(chalk.bold`status url:     `, blue(responseBody.status_url))

--- a/cli/src/commands/service/use-image.ts
+++ b/cli/src/commands/service/use-image.ts
@@ -35,11 +35,11 @@ export default class UseImage extends Command {
     }
 
     const service = parts[0]
-    const environment = parts[1] ?? 'default'
+    const environment = parts[1] ?? null
 
     await jamsocket.updateEnvironment(service, environment, flags.image)
 
-    const fullServiceName = environment === 'default' ? service : `${service}/${environment}`
+    const fullServiceName = environment ? `${service}/${environment}` : service
     this.log(`Updated ${lightMagenta(fullServiceName)} to use image ${blue(flags.image)}`)
     this.log(
       `Run ${lightBlue(`jamsocket service info ${service}`)} for more information about your service.`,

--- a/cli/src/commands/service/use-image.ts
+++ b/cli/src/commands/service/use-image.ts
@@ -3,19 +3,16 @@ import { Jamsocket } from '../../jamsocket'
 import { blue, lightBlue, lightMagenta } from '../../lib/formatting'
 
 export default class UseImage extends Command {
-  static description = 'Sets the image tag or digest to use when spawning a service/environment'
+  static description = 'Sets the image tag or digest to use when spawning a service'
 
-  static examples = [
-    '<%= config.bin %> <%= command.id %> my-service -i latest',
-    '<%= config.bin %> <%= command.id %> my-service/prod -i sha256:1234abcd',
-  ]
+  static examples = ['<%= config.bin %> <%= command.id %> my-service -i latest']
 
   static flags = {
     image: Flags.string({
       char: 'i',
       required: true,
       description:
-        'image tag or digest for the service/environment to use (Run `jamsocket images` for a list of images you can use.)',
+        'image tag or digest for the service to use (Run `jamsocket images` for a list of images you can use.)',
     }),
   }
 
@@ -23,8 +20,7 @@ export default class UseImage extends Command {
     {
       name: 'service',
       required: true,
-      description:
-        'Name of service/environment whose image should be updated. If only a service is provided, the "default" environment is used.',
+      description: 'Name of service whose spawning image should be updated.',
     },
   ]
 
@@ -35,7 +31,7 @@ export default class UseImage extends Command {
 
     const parts = args.service.split('/')
     if (parts.length > 2 || parts[0] === '' || parts[1] === '') {
-      this.error(`Invalid service/environment name: ${args.service}`)
+      this.error(`Invalid service name: ${args.service}`)
     }
 
     const service = parts[0]
@@ -43,11 +39,10 @@ export default class UseImage extends Command {
 
     await jamsocket.updateEnvironment(service, environment, flags.image)
 
+    const fullServiceName = environment === 'default' ? service : `${service}/${environment}`
+    this.log(`Updated ${lightMagenta(fullServiceName)} to use image ${blue(flags.image)}`)
     this.log(
-      `Updated ${lightMagenta(`${service}/${environment}`)} to use image ${blue(flags.image)}`,
-    )
-    this.log(
-      `Run ${lightBlue(`jamsocket service info ${service}`)} for more information about your service and its environments.`,
+      `Run ${lightBlue(`jamsocket service info ${service}`)} for more information about your service.`,
     )
   }
 }

--- a/cli/src/dev-server/index.ts
+++ b/cli/src/dev-server/index.ts
@@ -10,14 +10,13 @@ import {
   JamsocketConnectRequestBody,
   V1Status,
   JamsocketConnectResponse,
-  PlaneV2StatusMessage,
   HTTPError,
   V2Status,
   SpawnRequestBody,
 } from '../api'
 import { readRequestBody, createColorGetter, sleep, type Color } from './util'
 import { Logger } from './logger'
-import type { StreamHandle, PlaneConnectResponse } from './plane'
+import type { StreamHandle, PlaneConnectResponse, PlaneV2StatusMessage } from './plane'
 import {
   LocalPlane,
   runPlane,

--- a/cli/src/dev-server/plane.ts
+++ b/cli/src/dev-server/plane.ts
@@ -2,12 +2,13 @@ import { spawn, type ChildProcessWithoutNullStreams, spawnSync } from 'child_pro
 import readline from 'readline'
 import chalk from 'chalk'
 import EventSource from 'eventsource'
-import {
-  HTTPError,
+import { HTTPError } from '../api'
+import type {
+  PlaneTerminationKind,
+  PlaneTerminationReason,
   V2Status,
   JamsocketConnectRequestBody,
   ConnectResourceLimits,
-  PlaneV2StatusMessage,
 } from '../api'
 import { sleep } from './util'
 import { spawnDockerSync } from '../lib/docker'
@@ -50,6 +51,22 @@ export type PlaneConnectResponse = {
   status_url: string
   status: V2Status
 }
+
+export type PlaneV2StatusMessage =
+  | { status: 'scheduled'; time: number }
+  | { status: 'loading'; time: number }
+  | { status: 'starting'; time: number }
+  | { status: 'waiting'; time: number }
+  | { status: 'ready'; time: number }
+  | { status: 'terminating'; time: number; termination_reason: PlaneTerminationReason }
+  | { status: 'hard-terminating'; time: number; termination_reason: PlaneTerminationReason }
+  | {
+      status: 'terminated'
+      time: number
+      termination_reason?: PlaneTerminationReason | null
+      termination_kind?: PlaneTerminationKind | null
+      exit_error?: boolean
+    }
 
 export type StreamHandle = {
   closed: Promise<void>

--- a/cli/src/jamsocket.ts
+++ b/cli/src/jamsocket.ts
@@ -1,12 +1,4 @@
-import {
-  JamsocketApi,
-  BackendInfoResult,
-  RunningBackendsResult,
-  SpawnRequestBody,
-  SpawnResult,
-  PlaneV2StatusMessage,
-  TerminateResult,
-} from './api'
+import { JamsocketApi } from './api'
 import type {
   ServiceCreateResult,
   ServiceListResult,
@@ -16,6 +8,12 @@ import type {
   EnvironmentUpdateResult,
   JamsocketConnectRequestBody,
   JamsocketConnectResponse,
+  BackendInfoResult,
+  RunningBackendsResult,
+  SpawnRequestBody,
+  SpawnResult,
+  TerminateResult,
+  PublicV2State,
 } from './api'
 import { JamsocketConfig } from './jamsocket-config'
 import { tag as dockerTag, push as dockerPush } from './lib/docker'
@@ -156,13 +154,13 @@ export class Jamsocket {
 
   public streamStatus(
     backend: string,
-    callback: (v: PlaneV2StatusMessage) => void,
+    callback: (v: PublicV2State) => void,
     config?: JamsocketConfig,
   ): EventStreamReturn {
     return this.api.streamStatus(backend, callback, config)
   }
 
-  public status(backend: string, config?: JamsocketConfig): Promise<PlaneV2StatusMessage> {
+  public status(backend: string, config?: JamsocketConfig): Promise<PublicV2State> {
     return this.api.status(backend, config)
   }
 }

--- a/cli/src/jamsocket.ts
+++ b/cli/src/jamsocket.ts
@@ -130,14 +130,12 @@ export class Jamsocket {
 
   public updateEnvironment(
     service: string,
-    environment: string,
-    imageTag?: string,
-    newName?: string,
+    environment: string | null,
+    imageTag: string,
   ): Promise<EnvironmentUpdateResult> {
     const config = this.expectAuthorized()
     return this.api.updateEnvironment(config.getAccount(), service, environment, config, {
       image_tag: imageTag,
-      name: newName,
     })
   }
 


### PR DESCRIPTION
Doing a number of things here to bring the CLI in line with some changes to the platform:

- [x] Updated the names we give to args to make them more consistent (e.g. backend _IDs_ instead of _names_)
- [x] Updated the `image-name` and service update endpoints
- [x] Updates to support new status formats (in backend info functions, status functions, and in the dev command's dev server)
- [x] Added a better error message to the terminate command