### PR TITLE
update TypeScript libraries for v2 statuses and endpoints

### DIFF
--- a/.github/workflows/check-ts.yml
+++ b/.github/workflows/check-ts.yml
@@ -33,3 +33,7 @@ jobs:
     - name: Check Formatting of Socket.io lib
       run: npx prettier --check "src/**/*.{ts,tsx}"
       working-directory: packages/typescript/socketio/
+
+    - name: Check Formatting of types lib
+      run: npx prettier --check "src/**/*.{ts,tsx}"
+      working-directory: packages/typescript/types/

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -91,7 +91,7 @@ export type PlaneTerminationReason =
   | 'key_expired'
   | 'lost'
   | 'startup_timeout'
-  | 'internal-error'
+  | 'internal_error'
 
 // these are public messages that come over the status and status/stream endpoints
 export type PublicV2State =

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -33,6 +33,7 @@ export type V1Status =
   | 'ErrorLoading'
   | 'ErrorStarting'
   | 'TimedOutBeforeReady'
+  | 'Lost'
 
 export type V2Status =
   | 'scheduled'
@@ -90,6 +91,7 @@ export type PlaneTerminationReason =
   | 'key_expired'
   | 'lost'
   | 'startup_timeout'
+  | 'internal-error'
 
 // these are public messages that come over the status and status/stream endpoints
 export type PublicV2State =

--- a/cli/src/dev-server/index.ts
+++ b/cli/src/dev-server/index.ts
@@ -786,6 +786,9 @@ function translateStatusToV1(
       if (plane2StatusMsg.termination_reason === 'external') {
         return 'Terminated'
       }
+      if (plane2StatusMsg.termination_reason === 'internal-error') {
+        return 'Lost'
+      }
       if (
         plane2StatusMsg.termination_reason &&
         ['swept', 'key_expired'].includes(plane2StatusMsg.termination_reason)

--- a/cli/src/dev-server/index.ts
+++ b/cli/src/dev-server/index.ts
@@ -786,7 +786,7 @@ function translateStatusToV1(
       if (plane2StatusMsg.termination_reason === 'external') {
         return 'Terminated'
       }
-      if (plane2StatusMsg.termination_reason === 'internal-error') {
+      if (plane2StatusMsg.termination_reason === 'internal_error') {
         return 'Lost'
       }
       if (

--- a/examples/multiplayer-editor/package.json
+++ b/examples/multiplayer-editor/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@jamsocket/server": "0.2.5",
-    "@jamsocket/socketio": "0.2.5",
+    "@jamsocket/server": "1.0.0",
+    "@jamsocket/socketio": "1.0.0",
     "@types/node": "20.1.4",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",

--- a/examples/multiplayer-editor/src/app/page.tsx
+++ b/examples/multiplayer-editor/src/app/page.tsx
@@ -1,13 +1,13 @@
 import 'server-only';
 import HomeContainer from '../components/Home'
-import { init } from '@jamsocket/server'
+import { Jamsocket } from '@jamsocket/server'
 
-const WHITEBOARD_NAME = 'multiplayer-editor-demo/default'
+const WHITEBOARD_NAME = 'my-whiteboard-room'
 
-const spawnBackend = init({ dev: true })
+const jamsocket = new Jamsocket({ dev: true })
 
 // In production, you'll want to do the following instead:
-// const spawnBackend = init({
+// const jamsocket = new Jamsocket({
 //   account: '[YOUR ACCOUNT HERE]',
 //   service: 'whiteboard-demo',
 //   // NOTE: we want to keep the Jamsocket token secret, so we can only do this in a server component
@@ -15,6 +15,6 @@ const spawnBackend = init({ dev: true })
 // })
 
 export default async function Page() {
-  const spawnResult = await spawnBackend({ lock: WHITEBOARD_NAME })
-  return <HomeContainer spawnResult={spawnResult} />
+  const connectResponse = await jamsocket.connect({ key: WHITEBOARD_NAME })
+  return <HomeContainer connectResponse={connectResponse} />
 }

--- a/examples/multiplayer-editor/src/components/Home.tsx
+++ b/examples/multiplayer-editor/src/components/Home.tsx
@@ -5,12 +5,12 @@ import Header from './Header'
 import Content from './Content'
 import { AvatarList, Spinner, Whiteboard } from './Whiteboard'
 import type { Shape, User } from '../types'
-import { SocketIOProvider, useEventListener, useSend, SessionBackendProvider, useReady, type SpawnResult } from "@jamsocket/socketio"
+import { SocketIOProvider, useEventListener, useSend, SessionBackendProvider, useReady, type ConnectResponse } from "@jamsocket/socketio"
 
-export default function HomeContainer({ spawnResult }: { spawnResult: SpawnResult }) {
+export default function HomeContainer({ connectResponse }: { connectResponse: ConnectResponse }) {
   return (
-    <SessionBackendProvider spawnResult={spawnResult}>
-      <SocketIOProvider url={spawnResult.url}>
+    <SessionBackendProvider connectResponse={connectResponse}>
+      <SocketIOProvider url={connectResponse.url}>
         <Home />
       </SocketIOProvider>
     </SessionBackendProvider>

--- a/examples/multiplayer-editor/tsconfig.json
+++ b/examples/multiplayer-editor/tsconfig.json
@@ -9,7 +9,7 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
     "examples/multiplayer-editor": {
       "version": "0.1.0",
       "dependencies": {
-        "@jamsocket/server": "0.2.5",
-        "@jamsocket/socketio": "0.2.5",
+        "@jamsocket/server": "1.0.0",
+        "@jamsocket/socketio": "1.0.0",
         "@types/node": "20.1.4",
         "@types/react": "18.2.6",
         "@types/react-dom": "18.2.4",
@@ -5872,18 +5872,18 @@
     },
     "packages/typescript/client": {
       "name": "@jamsocket/client",
-      "version": "0.2.5",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/types": "^0.2.5"
+        "@jamsocket/types": "1.0.0"
       }
     },
     "packages/typescript/react": {
       "name": "@jamsocket/react",
-      "version": "0.2.5",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/client": "0.2.5"
+        "@jamsocket/client": "1.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.59"
@@ -5894,19 +5894,19 @@
     },
     "packages/typescript/server": {
       "name": "@jamsocket/server",
-      "version": "0.2.5",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/types": "^0.2.5",
+        "@jamsocket/types": "1.0.0",
         "isomorphic-fetch": "^3.0.0"
       }
     },
     "packages/typescript/socketio": {
       "name": "@jamsocket/socketio",
-      "version": "0.2.5",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/react": "0.2.5",
+        "@jamsocket/react": "1.0.0",
         "socket.io-client": "^4.7.4"
       },
       "devDependencies": {
@@ -5918,7 +5918,7 @@
     },
     "packages/typescript/types": {
       "name": "@jamsocket/types",
-      "version": "0.2.5",
+      "version": "1.0.0",
       "license": "MIT"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "packages/typescript/client",
         "packages/typescript/server",
         "packages/typescript/react",
-        "packages/typescript/socketio"
+        "packages/typescript/socketio",
+        "packages/typescript/types"
       ],
       "devDependencies": {
         "prettier": "^3.2.5",
@@ -623,6 +624,10 @@
     },
     "node_modules/@jamsocket/socketio": {
       "resolved": "packages/typescript/socketio",
+      "link": true
+    },
+    "node_modules/@jamsocket/types": {
+      "resolved": "packages/typescript/types",
       "link": true
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -5868,7 +5873,10 @@
     "packages/typescript/client": {
       "name": "@jamsocket/client",
       "version": "0.2.5",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@jamsocket/types": "^0.2.5"
+      }
     },
     "packages/typescript/react": {
       "name": "@jamsocket/react",
@@ -5889,6 +5897,7 @@
       "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
+        "@jamsocket/types": "^0.2.5",
         "isomorphic-fetch": "^3.0.0"
       }
     },
@@ -5906,6 +5915,11 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
+    },
+    "packages/typescript/types": {
+      "name": "@jamsocket/types",
+      "version": "0.2.5",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "packages/typescript/client",
     "packages/typescript/server",
     "packages/typescript/react",
-    "packages/typescript/socketio"
+    "packages/typescript/socketio",
+    "packages/typescript/types"
   ],
   "scripts": {
-    "clean": "npm run clean -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
+    "clean": "npm run clean -w packages/typescript/types -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
     "postinstall": "npm run build",
-    "build": "npm run build -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
-    "format": "npm run format -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
+    "build": "npm run build -w packages/typescript/types -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
+    "format": "npm run format -w packages/typescript/types -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
     "set-js-versions": "ts-node packages/scripts/set-js-versions.ts"
   },
   "license": "MIT",

--- a/packages/typescript/client/README.md
+++ b/packages/typescript/client/README.md
@@ -18,22 +18,22 @@ npm install @jamsocket/client
 Here's an example of how different parts of Jamsocket's client libraries work together.
 
 ```tsx filename="server.tsx"
-import Jamsocket from '@jamsocket/server'
+import { Jamsocket } from '@jamsocket/server'
 
-const jamsocket = Jamsocket.init({
+const jamsocket = new Jamsocket({
    account: '[YOUR ACCOUNT]',
    token: '[YOUR TOKEN]',
    service: '[YOUR SERVICE]',
    // during development, you can simply pass { dev: true }
 })
 
-const spawnResult = await jamsocket.spawn() // returns an instance of SpawnResult
+const connectResponse = await jamsocket.connect() // returns an instance of ConnectResponse
 ```
 
 ```tsx filename="client.ts"
 import { SessionBackend } from '@jamsocket/client'
 
-const sessionBackend = new SessionBackend(spawnResult.url, spawnResult.statusUrl)
+const sessionBackend = new SessionBackend(connectResponse)
 
 sessionBackend.isReady() // returns a boolean indicating if the session backend has started and is ready to receive connections
 sessionBackend.onReady(() => {
@@ -50,7 +50,7 @@ sessionBackend.onReady(() => {
 ```js
 import { SessionBackend } from '@jamsocket/client'
 
-const sessionBackend = new SessionBackend(spawnResultUrl, statusUrl)
+const sessionBackend = new SessionBackend(connectResponse)
 ```
 
 #### `isReady()`
@@ -60,22 +60,96 @@ const sessionBackend = new SessionBackend(spawnResultUrl, statusUrl)
 ```js {5}
 import { SessionBackend } from '@jamsocket/client'
 
-const sessionBackend = new SessionBackend(spawnResultUrl, statusUrl)
+const sessionBackend = new SessionBackend(connectResponse)
 
 const isReady = sessionBackend.isReady()
 ```
 
+#### `onReadyPromise`
+`onReadyPromise` is a Promise that resolves when the session backend is ready.
+
+```js {5}
+import { SessionBackend } from '@jamsocket/client'
+
+const sessionBackend = new SessionBackend(connectResponse)
+
+await sessionBackend.onReadyPromise
+```
+
 #### `onReady()`
-`onReady` takes a callback function that is called when the session backend is ready.
+`onReady` may be used as an alternative to the `onReadyPromise`. It may be called with a callback function that is called when the session backend is ready.
 
 ```js {5-7}
 import { SessionBackend } from '@jamsocket/client'
 
-const sessionBackend = new SessionBackend(spawnResultUrl, statusUrl)
+const sessionBackend = new SessionBackend(connectResponse)
 
 sessionBackend.onReady(() => {
     // your logic here
 })
+```
+
+#### `isTerminated()`
+`isTerminated` returns a boolean value that is `true` if the backend is no longer running.
+
+`isTerminated()`
+```js {5}
+import { SessionBackend } from '@jamsocket/client'
+
+const sessionBackend = new SessionBackend(connectResponse)
+
+const isTerminated = sessionBackend.isTerminated()
+```
+
+#### `onTerminatedPromise`
+`onTerminatedPromise` is a Promise that resolves when the session backend has stopped running.
+
+```js {5}
+import { SessionBackend } from '@jamsocket/client'
+
+const sessionBackend = new SessionBackend(connectResponse)
+
+await sessionBackend.onTerminatedPromise
+```
+
+#### `onTerminated()`
+`onTerminated` may be used as an alternative to the `onTerminatedPromise`. It may be called with a callback function that is called when the session backend has stopped running.
+
+```js {5-7}
+import { SessionBackend } from '@jamsocket/client'
+
+const sessionBackend = new SessionBackend(connectResponse)
+
+sessionBackend.onTerminated(() => {
+    // your logic here
+})
+```
+
+#### `status()`
+`status` returns a Promise that resolves with the backend's current `BackendState`.
+
+```js {5}
+import { SessionBackend } from '@jamsocket/client'
+
+const sessionBackend = new SessionBackend(connectResponse)
+
+const currentState = await sessionBackend.status()
+```
+
+#### `onStatus()`
+`onStatus` takes a callback which is called when the backend's status changes. It returns an unsubscribe function that may be called to unsubscribes the callback from the status changes.
+
+```js {5-7, 9-10}
+import { SessionBackend } from '@jamsocket/client'
+
+const sessionBackend = new SessionBackend(connectResponse)
+
+const unsubcribe = sessionBackend.onStatus((state: BackendState) => {
+    // your logic here
+})
+
+// later, you can unsubscribe by calling the returned function
+unsubscribe()
 ```
 
 #### `destroy()`
@@ -84,7 +158,7 @@ sessionBackend.onReady(() => {
 ```js {5}
 import { SessionBackend } from '@jamsocket/client'
 
-const sessionBackend = new SessionBackend(spawnResultUrl, statusUrl)
+const sessionBackend = new SessionBackend(connectResponse)
 
 sessionBackend.destroy()
 ```
@@ -92,11 +166,43 @@ sessionBackend.destroy()
 ## Types
 
 ```ts
-type SpawnResult = {
-  url: string
-  name: string
-  readyUrl: string
-  statusUrl: string
+type ConnectResponse = {
+  backend_id: string
   spawned: boolean
+  status: BackendStatus
+  token: string
+  url: string
+  secret_token?: string | null
+  status_url: string
+  ready_url: string
 }
+
+type BackendStatus =
+  | 'scheduled'
+  | 'loading'
+  | 'starting'
+  | 'waiting'
+  | 'ready'
+  | 'terminating'
+  | 'hard-terminating'
+  | 'terminated'
+
+type TerminationKind = 'soft' | 'hard'
+type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout'
+
+type BackendState =
+  | { status: 'scheduled'; time: string }
+  | { status: 'loading'; time: string }
+  | { status: 'starting'; time: string }
+  | { status: 'waiting'; time: string }
+  | { status: 'ready'; time: string }
+  | { status: 'terminating'; time: string; termination_reason: TerminationReason }
+  | { status: 'hard-terminating'; time: string; termination_reason: TerminationReason }
+  | {
+      status: 'terminated'
+      time: string
+      termination_reason?: TerminationReason | null
+      termination_kind?: TerminationKind | null
+      exit_error?: boolean | null
+    }
 ```

--- a/packages/typescript/client/README.md
+++ b/packages/typescript/client/README.md
@@ -188,7 +188,7 @@ type BackendStatus =
   | 'terminated'
 
 type TerminationKind = 'soft' | 'hard'
-type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout' | 'internal-error'
+type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout' | 'internal_error'
 
 type BackendState =
   | { status: 'scheduled'; time: string }

--- a/packages/typescript/client/README.md
+++ b/packages/typescript/client/README.md
@@ -188,7 +188,7 @@ type BackendStatus =
   | 'terminated'
 
 type TerminationKind = 'soft' | 'hard'
-type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout'
+type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout' | 'internal-error'
 
 type BackendState =
   | { status: 'scheduled'; time: string }

--- a/packages/typescript/client/package.json
+++ b/packages/typescript/client/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.5",
+  "version": "1.0.0",
   "description": "JavaScript/TypeScript libraries for interacting with session backends and the Jamsocket platform.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,6 +38,6 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/types": "^0.2.5"
+    "@jamsocket/types": "1.0.0"
   }
 }

--- a/packages/typescript/client/package.json
+++ b/packages/typescript/client/package.json
@@ -36,5 +36,8 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/jamsocket/jamsocket/issues"
+  },
+  "dependencies": {
+    "@jamsocket/types": "^0.2.5"
   }
 }

--- a/packages/typescript/react/README.md
+++ b/packages/typescript/react/README.md
@@ -18,25 +18,25 @@ npm install @jamsocket/react
 Here's an example of how different parts of Jamsocket's client libraries work together.
 
 ```tsx filename="server.tsx"
-import Jamsocket from '@jamsocket/server'
+import { Jamsocket } from '@jamsocket/server'
 
-const jamsocket = Jamsocket.init({
+const jamsocket = new Jamsocket({
    account: '[YOUR ACCOUNT]',
    token: '[YOUR TOKEN]',
    service: '[YOUR SERVICE]',
    // during development, you can simply pass { dev: true }
 })
 
-const spawnResult = await jamsocket.spawn() // returns an instance of SpawnResult
+const connectResponse = await jamsocket.connect() // returns an instance of ConnectResponse
 ```
 
 ```tsx filename="client.tsx"
-import { type SpawnResult, SessionBackendProvider, useReady } from '@jamsocket/react'
+import { type ConnectResponse, SessionBackendProvider, useReady } from '@jamsocket/react'
 
 function Root() {
   return(
-    <SessionBackendProvider spawnResult={spawnResult}>
-      <MyComponent sessionBackendUrl={spawnResult.url} />
+    <SessionBackendProvider connectResponse={connectResponse}>
+      <MyComponent sessionBackendUrl={connectResponse.url} />
     </SessionBackendProvider>
   )
 }
@@ -61,14 +61,14 @@ function MyComponent({ sessionBackendUrl }) {
 ### `SessionBackendProvider`
 Wrap the root of your project with the `SessionBackendProvider` so that the children components can utilize the React hooks.
 
-The `SessionBackendProvider` must be used in conjunction with `@jamsocket/server` in order to access the spawn result returned by the `spawn` function.
+The `SessionBackendProvider` must be used in conjunction with `@jamsocket/server` in order to access the connect response returned by the `connect` function.
 
 ```tsx
-import { SessionBackendProvider, type SpawnResult } from '@jamsocket/react'
+import { SessionBackendProvider, type ConnectResponse } from '@jamsocket/react'
 
-export default function HomeContainer({ spawnResult }: { spawnResult: SpawnResult }) {
+export default function HomeContainer({ connectResponse }: { connectResponse: ConnectResponse }) {
   return (
-    <SessionBackendProvider spawnResult={spawnResult}>
+    <SessionBackendProvider connectResponse={connectResponse}>
         <Home />
     </SessionBackendProvider>
   )

--- a/packages/typescript/react/package.json
+++ b/packages/typescript/react/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.5",
+  "version": "1.0.0",
   "description": "React hooks for interacting with session backends and the Jamsocket platform.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/client": "0.2.5"
+    "@jamsocket/client": "1.0.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"

--- a/packages/typescript/react/src/main.tsx
+++ b/packages/typescript/react/src/main.tsx
@@ -1,25 +1,24 @@
 import { createContext, useContext, useEffect, useState } from 'react'
-import { type SpawnResult, SessionBackend } from '@jamsocket/client'
+import { type ConnectResponse, SessionBackend } from '@jamsocket/client'
 export * from '@jamsocket/client'
 
 export const SessionBackendContext = createContext<SessionBackend | null>(null)
 
-export function SessionBackendProvider({
-  spawnResult,
-  children,
-}: {
-  spawnResult: SpawnResult
+type SessionBackendProviderProps = {
+  connectResponse: ConnectResponse
   children: React.ReactNode
-}) {
-  const { url, statusUrl } = spawnResult
+}
+
+export function SessionBackendProvider({ connectResponse, children }: SessionBackendProviderProps) {
   const [backend, setBackend] = useState<SessionBackend | null>(null)
 
   useEffect(() => {
-    setBackend(new SessionBackend(url, statusUrl))
+    setBackend(new SessionBackend(connectResponse))
     return () => {
       backend?.destroy()
     }
-  }, [url, statusUrl])
+    // the two pieces of state that, together, uniquely identify a SessionBackend connection
+  }, [connectResponse.url, connectResponse.backend_id])
   return (
     <SessionBackendContext.Provider value={backend}>
       {backend ? children : null}

--- a/packages/typescript/server/README.md
+++ b/packages/typescript/server/README.md
@@ -18,16 +18,16 @@ npm install @jamsocket/server
 Here's an example of how different parts of Jamsocket's client libraries work together.
 
 ```tsx filename="server.tsx"
-import Jamsocket from '@jamsocket/server'
+import { Jamsocket } from '@jamsocket/server'
 
-const jamsocket = Jamsocket.init({
+const jamsocket = new Jamsocket({
    account: '[YOUR ACCOUNT]',
    token: '[YOUR TOKEN]',
    service: '[YOUR SERVICE]',
    // during development, you can simply pass { dev: true }
 })
 
-const spawnResult = await jamsocket.spawn() // returns an instance of SpawnResult
+const connectResponse = await jamsocket.connect() // returns an instance of ConnectResponse
 ```
 
 ```tsx filename="client.tsx"
@@ -38,8 +38,8 @@ import {
 
 function Root() {
   return(
-    <SessionBackendProvider spawnResult={spawnResult}>
-      <SocketIOProvider url={spawnResult.url}>
+    <SessionBackendProvider connectResponse={connectResponse}>
+      <SocketIOProvider url={connectResponse.url}>
         <MyComponent />
       </SocketIOProvider>
     </SessionBackendProvider>
@@ -66,47 +66,61 @@ function MyComponent() {
 
 ## @jamsocket/server
 
-### `init()`
+### `Jamsocket`
 
-Create a Jamsocket instance using the `init` function from `@jamsocket/server` folder.
+Create a Jamsocket instance with the `Jamsocket` class from `@jamsocket/server` folder.
 
 In local development, you can simply set `dev` to `true`.
 
 ```ts
-import Jamsocket from '@jamsocket/server'
-const jamsocket = Jamsocket.init({ dev: true })
+import { Jamsocket } from '@jamsocket/server'
+const jamsocket = new Jamsocket({ dev: true })
 ```
 
 In production, provide your `account`, `token`, and `service` information.
 
 ```ts
-import Jamsocket from '@jamsocket/server'
-const jamsocket = Jamsocket.init({
+import { Jamsocket } from '@jamsocket/server'
+const jamsocket = new Jamsocket({
   account: '[YOUR ACCOUNT]',
   token: '[YOUR TOKEN]',
   service: '[YOUR SERVICE]',
 })
 ```
 
-### `spawn()`
+### `connect()`
 
-The returned Jamsocket instance from `init` includes a `spawn` function that you can use to spawn a session backend. You can optionally include a [`lock`](/concepts/locks), environment variables, and a grace period when you spawn.
+The Jamsocket instance includes a `connect` function that you can use to get a connection URL for a session backend. If you provide a `key`, the connect function will either spawn a new backend or return the running backend that holds the provided key if one exists. When generating a connection URL for a backend, you can provide an optional `ConnectRequest` object. It returns a promise, which resolves with a `ConnectResponse`.
 
-<Callout>Backends should only be spawned server-side, since the Jamsocket Auth Token must be kept secret.</Callout>
+Learn more about the various options you can pass in a `ConnectRequest` in [our API docs](https://docs.jamsocket.com/platform/reference/v2#get-a-connection-url-for-a-backend).
+
+<Callout>A Jamsocket class should only be instantiated on the server since it takes a Jamsocket Auth Token which must be kept secret.</Callout>
 
 ```ts {8-12}
-import Jamsocket from '@jamsocket/server'
-const jamsocket = Jamsocket.init({
+import { Jamsocket } from '@jamsocket/server'
+const jamsocket = new Jamsocket({
   account: '[YOUR ACCOUNT]',
   token: '[YOUR TOKEN]',
   service: '[YOUR SERVICE]',
 })
 
-const spawnResult = await jamsocket.spawn({
-  tag: 'latest', // optional
-  lock: 'my-lock', // optional
-  env: { MY_ENV_VAR: 'foo' }, // optional
-  gracePeriodSeconds: 300, // optional
+const connectResponse = await jamsocket.connect() // no options are required
+
+// or
+
+const connectResponse = await jamsocket.connect({
+  key: 'my-key',
+  spawn: {
+    lifetime_limit_seconds: 432_000, // 10 hours
+    max_idle_seconds: 300, // 5 minutes
+    executable: {
+      env: {
+        'MY_ENV_VAR': 'foo'
+      }
+    }
+  },
+  user: 'my-user-id', // optional user identifier to be included in request headers to session backend
+  auth: { 'my_user_metadata': 'bar' } // optional values to be JSON-serialized and included in request headers to session backend
 })
 ```
 
@@ -125,19 +139,50 @@ type JamsocketInitOptions =
       port?: number
     }
 
-type JamsocketSpawnOptions = {
-  tag?: string
-  lock?: string
-  env?: Record<string, string>
-  gracePeriodSeconds?: number
-  serviceEnvironment?: string
+type ConnectRequest = {
+  key?: string
+  spawn?:
+    | boolean
+    | {
+        tag?: string
+        lifetime_limit_seconds?: number
+        max_idle_seconds?: number
+        executable?: {
+          mount?: string | boolean
+          env?: Record<string, string>
+          resource_limits?: {
+            cpu_period?: number
+            // Proportion of period used by container (in microseconds)
+            cpu_period_percent?: number
+            // Total cpu time allocated to container (in seconds)
+            cpu_time_limit?: number
+            memory_limit_bytes?: number
+            disk_limit_bytes?: number
+          }
+        }
+      }
+  user?: string
+  auth?: Record<string, any>
 }
 
-type SpawnResult = {
-  url: string
-  name: string
-  readyUrl: string
-  statusUrl: string
+type ConnectResponse = {
+  backend_id: string
   spawned: boolean
+  status: BackendStatus
+  token: string
+  url: string
+  secret_token?: string | null
+  status_url: string
+  ready_url: string
 }
+
+type BackendStatus =
+  | 'scheduled'
+  | 'loading'
+  | 'starting'
+  | 'waiting'
+  | 'ready'
+  | 'terminating'
+  | 'hard-terminating'
+  | 'terminated'
 ```

--- a/packages/typescript/server/package.json
+++ b/packages/typescript/server/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.5",
+  "version": "1.0.0",
   "description": "JavaScript/TypeScript libraries for spawning session backends server-side.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/types": "^0.2.5",
+    "@jamsocket/types": "1.0.0",
     "isomorphic-fetch": "^3.0.0"
   }
 }

--- a/packages/typescript/server/src/main.ts
+++ b/packages/typescript/server/src/main.ts
@@ -1,13 +1,13 @@
 import 'isomorphic-fetch' // fetch polyfill for older versions of Node
-
-export type SpawnResult = {
-  url: string
-  name: string
-  readyUrl: string
-  statusUrl: string
-  spawned: boolean
-  status: string
-}
+import type { ConnectRequest, ConnectResponse } from '@jamsocket/types'
+export type {
+  BackendStatus,
+  TerminationKind,
+  TerminationReason,
+  BackendState,
+  ConnectResponse,
+  ConnectRequest,
+} from '@jamsocket/types'
 
 export type JamsocketDevInitOptions = {
   dev: true
@@ -23,22 +23,6 @@ export type JamsocketInitOptions =
     }
   | JamsocketDevInitOptions
 
-export type JamsocketSpawnOptions = {
-  tag?: string
-  lock?: string
-  env?: Record<string, string>
-  gracePeriodSeconds?: number
-  serviceEnvironment?: string
-}
-
-type JamsocketApiSpawnBody = {
-  tag?: string
-  lock?: string
-  env?: Record<string, string>
-  grace_period_seconds?: number
-  service_environment?: string
-}
-
 const JAMSOCKET_DEV_PORT = 8080
 const JAMSOCKET_API = 'https://api.jamsocket.com'
 
@@ -53,75 +37,50 @@ function validatePort(port: any): number {
   return port
 }
 
-export type JamsocketInstance = {
-  /**
-   * @deprecated Calling a `JamsocketInstance` as a function is deprecated. Use the `spawn` method instead.
-   */
-  (opts: JamsocketSpawnOptions): Promise<SpawnResult>
-  spawn(opts: JamsocketSpawnOptions): Promise<SpawnResult>
-}
+export class Jamsocket {
+  account: string
+  service: string
+  token: string
+  apiUrl: string
 
-export function init(opts: JamsocketInitOptions): JamsocketInstance {
-  let account: string
-  let token: string
-  let service: string
-  let apiUrl: string
-
-  if (isJamsocketDevInitOptions(opts)) {
-    account = '-'
-    token = '-'
-    service = '-'
-    const port = opts.port ? validatePort(opts.port) : JAMSOCKET_DEV_PORT
-    apiUrl = `http://localhost:${port}`
-  } else {
-    account = opts.account
-    token = opts.token
-    service = opts.service
-    apiUrl = opts.apiUrl || JAMSOCKET_API
+  constructor(opts: JamsocketInitOptions) {
+    if (isJamsocketDevInitOptions(opts)) {
+      this.account = '-'
+      this.token = '-'
+      this.service = '-'
+      const port = opts.port ? validatePort(opts.port) : JAMSOCKET_DEV_PORT
+      this.apiUrl = `http://localhost:${port}`
+    } else {
+      this.account = opts.account
+      this.token = opts.token
+      this.service = opts.service
+      this.apiUrl = opts.apiUrl || JAMSOCKET_API
+    }
   }
 
-  const spawnInner = async function (spawnOpts: JamsocketSpawnOptions = {}): Promise<SpawnResult> {
-    const reqBody: JamsocketApiSpawnBody = {}
-    if (spawnOpts.tag) reqBody.tag = spawnOpts.tag
-    if (spawnOpts.lock) reqBody.lock = spawnOpts.lock
-    if (spawnOpts.env) reqBody.env = spawnOpts.env
-    if (spawnOpts.gracePeriodSeconds) reqBody.grace_period_seconds = spawnOpts.gracePeriodSeconds
-    if (spawnOpts.serviceEnvironment) reqBody.service_environment = spawnOpts.serviceEnvironment
-
-    const response = await fetch(`${apiUrl}/user/${account}/service/${service}/spawn`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify(reqBody),
-      cache: 'no-store',
-    })
+  async connect(connectRequest?: ConnectRequest): Promise<ConnectResponse> {
+    const response = await fetch(
+      `${this.apiUrl}/v2/service/${this.account}/${this.service}/connect`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${this.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(connectRequest || {}),
+        cache: 'no-store',
+      },
+    )
+    const bodyText = await response.text()
     if (!response.ok) {
       if (response.status === 429) {
         console.warn(
           "You've hit the spawn rate limit. This may be because you've spawned too many session backends in a short period of time or you're already running the maximum number of concurrent session backends. (related: https://docs.jamsocket.com/pricing/free-tier-limits)",
         )
       }
-      throw new Error(`Error spawning backend: ${response.status} ${await response.text()}`)
+      throw new Error(`Error spawning backend: ${response.status} ${bodyText}`)
     }
-    const body = await response.json()
-    return {
-      url: body.url,
-      name: body.name,
-      readyUrl: body.ready_url,
-      statusUrl: body.status_url,
-      spawned: body.spawned,
-      status: body.status,
+    try {
+      return JSON.parse(bodyText) as ConnectResponse
+    } catch (e) {
+      throw new Error(`Error parsing connect response: ${bodyText}`)
     }
   }
-
-  const spawn = async function (spawnOpts: JamsocketSpawnOptions = {}): Promise<SpawnResult> {
-    console.warn(
-      'Calling the result of Jamsocket.init(...)() directly is deprecated, call Jamsocket.init().spawn(...) instead.',
-    )
-    return spawnInner(spawnOpts)
-  }
-
-  spawn.spawn = spawnInner
-  return spawn
 }
-
-export default { init }

--- a/packages/typescript/socketio/README.md
+++ b/packages/typescript/socketio/README.md
@@ -18,29 +18,28 @@ npm install @jamsocket/socketio
 Here's an example of how different parts of Jamsocket's client libraries work together.
 
 ```tsx filename="server.tsx"
-import Jamsocket from '@jamsocket/server'
+import { Jamsocket } from '@jamsocket/server'
 
-const jamsocket = Jamsocket.init({
+const jamsocket = new Jamsocket({
    account: '[YOUR ACCOUNT]',
    token: '[YOUR TOKEN]',
    service: '[YOUR SERVICE]',
    // during development, you can simply pass { dev: true }
 })
 
-const spawnResult = await jamsocket.spawn() // returns an instance of SpawnResult
+const connectResponse = await jamsocket.connect() // returns an instance of ConnectResponse
 ```
 
 ```tsx filename="client.tsx"
 import {
-  type SpawnResult,
   SessionBackendProvider, SocketIOProvider,
   useEventListener, useSend, useReady
 } from '@jamsocket/socketio'
 
 function Root() {
   return(
-    <SessionBackendProvider spawnResult={spawnResult}>
-      <SocketIOProvider url={spawnResult.url}>
+    <SessionBackendProvider connectResponse={connectResponse}>
+      <SocketIOProvider url={connectResponse.url}>
         <MyComponent />
       </SocketIOProvider>
     </SessionBackendProvider>
@@ -69,7 +68,7 @@ function MyComponent() {
 
 ### `SocketIOProvider`
 
-The `SocketIOProvider` uses the url returned from the `spawn` function to connect to a SocketIO server running in your session backend.
+The `SocketIOProvider` uses the url returned from the `connect` function to connect to a SocketIO server running in your session backend.
 
 Using the `SocketIOProvider` lets you use the React hooks in `@jamsocket/socketio`. It must be used in conjunction with `@jamsocket/server` and `@jamsocket/react` in order to properly access the session backend.
 
@@ -79,10 +78,10 @@ The `SocketIOProvider` must be a child of the `SessionBackendProvider` because i
 import { SessionBackendProvider, type SpawnResult } from '@jamsocket/react'
 import { SocketIOProvider } from '@jamsocket/socketio'
 
-export default function HomeContainer({ spawnResult }: { spawnResult: SpawnResult }) {
+export default function HomeContainer({ connectResponse }: { connectResponse: ConnectResponse }) {
   return (
-    <SessionBackendProvider spawnResult={spawnResult}>
-      <SocketIOProvider url={spawnResult.url}>
+    <SessionBackendProvider connectResponse={connectResponse}>
+      <SocketIOProvider url={connectResponse.url}>
           <Home />
       </SocketIOProvider>
     </SessionBackendProvider>

--- a/packages/typescript/socketio/package.json
+++ b/packages/typescript/socketio/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.5",
+  "version": "1.0.0",
   "description": "React hooks for interacting with socket.io servers in Jamsocket session backends.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/react": "0.2.5",
+    "@jamsocket/react": "1.0.0",
     "socket.io-client": "^4.7.4"
   },
   "peerDependencies": {

--- a/packages/typescript/types/README.md
+++ b/packages/typescript/types/README.md
@@ -115,7 +115,7 @@ type BackendStatus =
   | 'terminated'
 
 type TerminationKind = 'soft' | 'hard'
-type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout'
+type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout' | 'internal-error'
 
 type BackendState =
   | { status: 'scheduled'; time: string }

--- a/packages/typescript/types/README.md
+++ b/packages/typescript/types/README.md
@@ -115,7 +115,7 @@ type BackendStatus =
   | 'terminated'
 
 type TerminationKind = 'soft' | 'hard'
-type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout' | 'internal-error'
+type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout' | 'internal_error'
 
 type BackendState =
   | { status: 'scheduled'; time: string }

--- a/packages/typescript/types/README.md
+++ b/packages/typescript/types/README.md
@@ -18,16 +18,16 @@ npm install @jamsocket/types
 Here's an example of how different parts of Jamsocket's client libraries work together.
 
 ```tsx filename="server.tsx"
-import Jamsocket from '@jamsocket/server'
+import { Jamsocket } from '@jamsocket/server'
 
-const jamsocket = Jamsocket.init({
+const jamsocket = new Jamsocket({
    account: '[YOUR ACCOUNT]',
    token: '[YOUR TOKEN]',
    service: '[YOUR SERVICE]',
    // during development, you can simply pass { dev: true }
 })
 
-const spawnResult = await jamsocket.spawn() // returns an instance of SpawnResult
+const connectResponse = await jamsocket.connect() // returns an instance of ConnectResponse
 ```
 
 ```tsx filename="client.tsx"
@@ -38,8 +38,8 @@ import {
 
 function Root() {
   return(
-    <SessionBackendProvider spawnResult={spawnResult}>
-      <SocketIOProvider url={spawnResult.url}>
+    <SessionBackendProvider connectResponse={connectResponse}>
+      <SocketIOProvider url={connectResponse.url}>
         <MyComponent />
       </SocketIOProvider>
     </SessionBackendProvider>

--- a/packages/typescript/types/README.md
+++ b/packages/typescript/types/README.md
@@ -1,0 +1,135 @@
+# @jamsocket/types
+
+[![GitHub Repo stars](https://img.shields.io/github/stars/jamsocket/jamsocket?style=social)](https://github.com/jamsocket/jamsocket)
+[![Chat on Discord](https://img.shields.io/discord/939641163265232947)](https://discord.gg/N5sEpsuhh9)
+[![npm](https://img.shields.io/npm/v/@jamsocket/server)](https://www.npmjs.com/package/@jamsocket/server)
+
+JavaScript/TypeScript library for spawning session backends server-side.
+
+Read the [docs here](https://docs.jamsocket.com)
+
+## Installation
+```bash copy
+npm install @jamsocket/types
+```
+
+## Example
+
+Here's an example of how different parts of Jamsocket's client libraries work together.
+
+```tsx filename="server.tsx"
+import Jamsocket from '@jamsocket/server'
+
+const jamsocket = Jamsocket.init({
+   account: '[YOUR ACCOUNT]',
+   token: '[YOUR TOKEN]',
+   service: '[YOUR SERVICE]',
+   // during development, you can simply pass { dev: true }
+})
+
+const spawnResult = await jamsocket.spawn() // returns an instance of SpawnResult
+```
+
+```tsx filename="client.tsx"
+import {
+  SessionBackendProvider, SocketIOProvider,
+  useEventListener, useSend, useReady
+} from '@jamsocket/socketio'
+
+function Root() {
+  return(
+    <SessionBackendProvider spawnResult={spawnResult}>
+      <SocketIOProvider url={spawnResult.url}>
+        <MyComponent />
+      </SocketIOProvider>
+    </SessionBackendProvider>
+  )
+}
+
+function MyComponent() {
+  const ready = useReady()
+  const sendEvent = useSend()
+
+  useEffect(() => {
+    if (ready) {
+      sendEvent('some-event', someValue)
+    }
+  }, [ready])
+
+  useEventListener('another-event', (args) => {
+    // do something when receiving an event message from your session backend...
+  })
+}
+```
+
+# Library Reference
+
+## @jamsocket/types
+
+```ts
+type ConnectResponse = {
+  backend_id: string
+  spawned: boolean
+  status: BackendStatus
+  token: string
+  url: string
+  secret_token?: string | null
+  status_url: string
+  ready_url: string
+}
+
+type ConnectRequest = {
+  key?: string
+  spawn?:
+    | boolean
+    | {
+        tag?: string
+        lifetime_limit_seconds?: number
+        max_idle_seconds?: number
+        executable?: {
+          mount?: string | boolean
+          env?: Record<string, string>
+          resource_limits?: {
+            cpu_period?: number
+            // Proportion of period used by container (in microseconds)
+            cpu_period_percent?: number
+            // Total cpu time allocated to container (in seconds)
+            cpu_time_limit?: number
+            memory_limit_bytes?: number
+            disk_limit_bytes?: number
+          }
+        }
+      }
+  user?: string
+  auth?: Record<string, any>
+}
+
+type BackendStatus =
+  | 'scheduled'
+  | 'loading'
+  | 'starting'
+  | 'waiting'
+  | 'ready'
+  | 'terminating'
+  | 'hard-terminating'
+  | 'terminated'
+
+type TerminationKind = 'soft' | 'hard'
+type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout'
+
+type BackendState =
+  | { status: 'scheduled'; time: string }
+  | { status: 'loading'; time: string }
+  | { status: 'starting'; time: string }
+  | { status: 'waiting'; time: string }
+  | { status: 'ready'; time: string }
+  | { status: 'terminating'; time: string; termination_reason: TerminationReason }
+  | { status: 'hard-terminating'; time: string; termination_reason: TerminationReason }
+  | {
+      status: 'terminated'
+      time: string
+      termination_reason?: TerminationReason | null
+      termination_kind?: TerminationKind | null
+      exit_error?: boolean | null
+    }
+```

--- a/packages/typescript/types/package.json
+++ b/packages/typescript/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jamsocket/server",
+  "name": "@jamsocket/types",
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf dist",
@@ -13,13 +13,10 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/main.d.mts",
-        "default": "./dist/main.mjs"
+        "types": "./dist/main.d.mts"
       },
       "require": {
-        "types": "./dist/main.d.ts",
-        "module": "./dist/main.mjs",
-        "default": "./dist/main.js"
+        "types": "./dist/main.d.ts"
       }
     }
   },
@@ -31,14 +28,10 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jamsocket/jamsocket.git",
-    "directory": "packages/typescript/server"
+    "directory": "packages/typescript/types"
   },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/jamsocket/jamsocket/issues"
-  },
-  "dependencies": {
-    "@jamsocket/types": "^0.2.5",
-    "isomorphic-fetch": "^3.0.0"
   }
 }

--- a/packages/typescript/types/package.json
+++ b/packages/typescript/types/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "0.2.5",
+  "version": "1.0.0",
   "description": "JavaScript/TypeScript libraries for spawning session backends server-side.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/packages/typescript/types/src/main.ts
+++ b/packages/typescript/types/src/main.ts
@@ -1,0 +1,65 @@
+export type BackendStatus =
+  | 'scheduled'
+  | 'loading'
+  | 'starting'
+  | 'waiting'
+  | 'ready'
+  | 'terminating'
+  | 'hard-terminating'
+  | 'terminated'
+
+export type TerminationKind = 'soft' | 'hard'
+export type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout'
+
+export type BackendState =
+  | { status: 'scheduled'; time: string }
+  | { status: 'loading'; time: string }
+  | { status: 'starting'; time: string }
+  | { status: 'waiting'; time: string }
+  | { status: 'ready'; time: string }
+  | { status: 'terminating'; time: string; termination_reason: TerminationReason }
+  | { status: 'hard-terminating'; time: string; termination_reason: TerminationReason }
+  | {
+      status: 'terminated'
+      time: string
+      termination_reason?: TerminationReason | null
+      termination_kind?: TerminationKind | null
+      exit_error?: boolean | null
+    }
+
+export type ConnectResponse = {
+  backend_id: string
+  spawned: boolean
+  status: BackendStatus
+  token: string
+  url: string
+  secret_token?: string | null
+  status_url: string
+  ready_url: string
+}
+
+export type ConnectRequest = {
+  key?: string
+  spawn?:
+    | boolean
+    | {
+        tag?: string
+        lifetime_limit_seconds?: number
+        max_idle_seconds?: number
+        executable?: {
+          mount?: string | boolean
+          env?: Record<string, string>
+          resource_limits?: {
+            cpu_period?: number
+            // Proportion of period used by container (in microseconds)
+            cpu_period_percent?: number
+            // Total cpu time allocated to container (in seconds)
+            cpu_time_limit?: number
+            memory_limit_bytes?: number
+            disk_limit_bytes?: number
+          }
+        }
+      }
+  user?: string
+  auth?: Record<string, any>
+}

--- a/packages/typescript/types/src/main.ts
+++ b/packages/typescript/types/src/main.ts
@@ -15,7 +15,7 @@ export type TerminationReason =
   | 'key_expired'
   | 'lost'
   | 'startup_timeout'
-  | 'internal-error'
+  | 'internal_error'
 
 export type BackendState =
   | { status: 'scheduled'; time: string }

--- a/packages/typescript/types/src/main.ts
+++ b/packages/typescript/types/src/main.ts
@@ -9,7 +9,7 @@ export type BackendStatus =
   | 'terminated'
 
 export type TerminationKind = 'soft' | 'hard'
-export type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout'
+export type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout' | 'internal-error'
 
 export type BackendState =
   | { status: 'scheduled'; time: string }

--- a/packages/typescript/types/src/main.ts
+++ b/packages/typescript/types/src/main.ts
@@ -9,7 +9,13 @@ export type BackendStatus =
   | 'terminated'
 
 export type TerminationKind = 'soft' | 'hard'
-export type TerminationReason = 'swept' | 'external' | 'key_expired' | 'lost' | 'startup_timeout' | 'internal-error'
+export type TerminationReason =
+  | 'swept'
+  | 'external'
+  | 'key_expired'
+  | 'lost'
+  | 'startup_timeout'
+  | 'internal-error'
 
 export type BackendState =
   | { status: 'scheduled'; time: string }

--- a/packages/typescript/types/tsconfig.json
+++ b/packages/typescript/types/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src/**/*"]
+}

--- a/packages/typescript/types/tsup.config.ts
+++ b/packages/typescript/types/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/main.ts'],
+  dts: true,
+  splitting: true,
+  clean: true,
+})


### PR DESCRIPTION
This PR does a few things:
* adds an `@jamsocket/types` package (this is re-exported by all packages so it shouldn't normally need to be a dependency)
* updates all packages to work with v2 endpoints (i.e. `connect()`) and v2 statuses
* updates all the packages' READMEs / docs
* updates the multiplayer-editor example

Note: this update is _not_ backwards compatible, so this will bring with it a major version bump.