### PR TITLE
add status() and statusStream() fns to @jamsocket/server + add session backend client library

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/examples/multiplayer-editor/package.json
+++ b/examples/multiplayer-editor/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@jamsocket/server": "1.0.0",
-    "@jamsocket/socketio": "1.0.0",
+    "@jamsocket/server": "1.1.0",
+    "@jamsocket/socketio": "1.1.0",
     "next": "13.4.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
       "workspaces": [
         "examples/multiplayer-editor",
         "packages/typescript/client",
-        "packages/typescript/server",
         "packages/typescript/react",
+        "packages/typescript/server",
         "packages/typescript/socketio",
         "packages/typescript/types"
       ],
@@ -30,8 +30,8 @@
     "examples/multiplayer-editor": {
       "version": "0.1.0",
       "dependencies": {
-        "@jamsocket/server": "1.0.0",
-        "@jamsocket/socketio": "1.0.0",
+        "@jamsocket/server": "1.1.0",
+        "@jamsocket/socketio": "1.1.0",
         "next": "13.4.9",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -4117,15 +4117,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
@@ -4581,44 +4572,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -6425,11 +6378,6 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
-    },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
@@ -6706,18 +6654,18 @@
     },
     "packages/typescript/client": {
       "name": "@jamsocket/client",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/types": "1.0.0"
+        "@jamsocket/types": "1.1.0"
       }
     },
     "packages/typescript/react": {
       "name": "@jamsocket/react",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/client": "1.0.0"
+        "@jamsocket/client": "1.1.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.59"
@@ -6728,19 +6676,18 @@
     },
     "packages/typescript/server": {
       "name": "@jamsocket/server",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/types": "1.0.0",
-        "isomorphic-fetch": "^3.0.0"
+        "@jamsocket/types": "1.1.0"
       }
     },
     "packages/typescript/socketio": {
       "name": "@jamsocket/socketio",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/react": "1.0.0",
+        "@jamsocket/react": "1.1.0",
         "socket.io-client": "^4.7.4"
       },
       "devDependencies": {
@@ -6752,7 +6699,7 @@
     },
     "packages/typescript/types": {
       "name": "@jamsocket/types",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,16 +6,16 @@
   "workspaces": [
     "examples/multiplayer-editor",
     "packages/typescript/client",
-    "packages/typescript/server",
     "packages/typescript/react",
+    "packages/typescript/server",
     "packages/typescript/socketio",
     "packages/typescript/types"
   ],
   "scripts": {
-    "clean": "npm run clean -w packages/typescript/types -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
+    "clean": "npm run clean -w packages/typescript/types -w packages/typescript/session-backend -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
     "postinstall": "npm run build",
-    "build": "npm run build -w packages/typescript/types -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
-    "format": "npm run format -w packages/typescript/types -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
+    "build": "npm run build -w packages/typescript/types -w packages/typescript/session-backend -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
+    "format": "npm run format -w packages/typescript/types -w packages/typescript/session-backend -w packages/typescript/client -w packages/typescript/server -w packages/typescript/react -w packages/typescript/socketio",
     "set-js-versions": "ts-node packages/scripts/set-js-versions.ts"
   },
   "license": "MIT",

--- a/packages/typescript/client/package.json
+++ b/packages/typescript/client/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "JavaScript/TypeScript libraries for interacting with session backends and the Jamsocket platform.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,6 +38,6 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/types": "1.0.0"
+    "@jamsocket/types": "1.1.0"
   }
 }

--- a/packages/typescript/client/src/main.ts
+++ b/packages/typescript/client/src/main.ts
@@ -71,7 +71,7 @@ export class SessionBackend {
   private fetchStatusStream = async () => {
     if (this.isTerminated() || this.fetchingStatusStream) return
     this.fetchingStatusStream = true
-    const response = await fetch(`${this.statusUrl}/stream`, { cache: 'no-store' })
+    const response = await fetch(`${this.statusUrl}/stream`)
     if (!response.body) {
       this.fetchingStatusStream = false
       throw new Error('response to Jamsocket backend status stream did not include body')
@@ -128,11 +128,11 @@ export class SessionBackend {
   }
 
   public async status(): Promise<BackendState> {
-    let res = await fetch(this.statusUrl, { mode: 'cors', cache: 'no-store' })
+    let res = await fetch(this.statusUrl, { mode: 'cors' })
     // if the first request fails, retry once
     if (!res.ok) {
       await new Promise((resolve) => setTimeout(resolve, 500))
-      res = await fetch(this.statusUrl, { mode: 'cors', cache: 'no-store' })
+      res = await fetch(this.statusUrl, { mode: 'cors' })
     }
     if (!res.ok) {
       throw new Error(

--- a/packages/typescript/react/package.json
+++ b/packages/typescript/react/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "React hooks for interacting with session backends and the Jamsocket platform.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/client": "1.0.0"
+    "@jamsocket/client": "1.1.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"

--- a/packages/typescript/server/package.json
+++ b/packages/typescript/server/package.json
@@ -38,7 +38,6 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/types": "1.0.0",
-    "isomorphic-fetch": "^3.0.0"
+    "@jamsocket/types": "1.0.0"
   }
 }

--- a/packages/typescript/server/package.json
+++ b/packages/typescript/server/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "JavaScript/TypeScript libraries for spawning session backends server-side.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,6 +38,6 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/types": "1.0.0"
+    "@jamsocket/types": "1.1.0"
   }
 }

--- a/packages/typescript/server/src/main.ts
+++ b/packages/typescript/server/src/main.ts
@@ -63,7 +63,6 @@ export class Jamsocket {
         method: 'POST',
         headers: { Authorization: `Bearer ${this.token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify(connectRequest || {}),
-        cache: 'no-store',
       }),
     )
     return parseAs<ConnectResponse>(isConnectResponse, await response.text())
@@ -71,7 +70,7 @@ export class Jamsocket {
 
   async status(backendId: string): Promise<BackendState> {
     const url = `${this.apiUrl}/v2/backend/${backendId}/status`
-    const response = checkResponse('status()', await fetch(url, { cache: 'no-store' }))
+    const response = checkResponse('status()', await fetch(url))
     return parseAs<BackendState>(isBackendState, await response.text())
   }
 
@@ -92,7 +91,7 @@ export class Jamsocket {
 
     async function startStatusStream() {
       try {
-        const response = checkResponse('statusStream()', await fetch(url, { cache: 'no-store' }))
+        const response = checkResponse('statusStream()', await fetch(url))
         // make sure only one streamReader is running at a time
         if (streamReader !== null) streamReader.cancel()
         streamReader = response.body.pipeThrough(new TextDecoderStream()).getReader()

--- a/packages/typescript/server/src/main.ts
+++ b/packages/typescript/server/src/main.ts
@@ -1,5 +1,7 @@
-import 'isomorphic-fetch' // fetch polyfill for older versions of Node
-import type { ConnectRequest, ConnectResponse } from '@jamsocket/types'
+import type { ConnectRequest, ConnectResponse, BackendState, BackendStatus } from '@jamsocket/types'
+import { isConnectResponse, isBackendState } from '@jamsocket/types'
+import { validatePort, checkResponse, parseAs } from './utils'
+export { isConnectResponse, isBackendState, HTTPError } from '@jamsocket/types'
 export type {
   BackendStatus,
   TerminationKind,
@@ -23,18 +25,14 @@ export type JamsocketInitOptions =
     }
   | JamsocketDevInitOptions
 
+export type OnStatusCallback = (backendState: BackendState) => void
+export type UnsubscribeFn = () => void
+
 const JAMSOCKET_DEV_PORT = 8080
 const JAMSOCKET_API = 'https://api.jamsocket.com'
 
 function isJamsocketDevInitOptions(opts: any): opts is JamsocketDevInitOptions {
   return opts.dev === true
-}
-
-function validatePort(port: any): number {
-  if (!Number.isInteger(port)) {
-    throw new Error(`Jamsocket dev port must be an integer, got ${typeof port}`)
-  }
-  return port
 }
 
 export class Jamsocket {
@@ -59,28 +57,89 @@ export class Jamsocket {
   }
 
   async connect(connectRequest?: ConnectRequest): Promise<ConnectResponse> {
-    const response = await fetch(
-      `${this.apiUrl}/v2/service/${this.account}/${this.service}/connect`,
-      {
+    const response = checkResponse(
+      'connect()',
+      await fetch(`${this.apiUrl}/v2/service/${this.account}/${this.service}/connect`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${this.token}`, 'Content-Type': 'application/json' },
         body: JSON.stringify(connectRequest || {}),
         cache: 'no-store',
-      },
+      }),
     )
-    const bodyText = await response.text()
-    if (!response.ok) {
-      if (response.status === 429) {
-        console.warn(
-          "You've hit the spawn rate limit. This may be because you've spawned too many session backends in a short period of time or you're already running the maximum number of concurrent session backends. (related: https://docs.jamsocket.com/pricing/free-tier-limits)",
-        )
+    return parseAs<ConnectResponse>(isConnectResponse, await response.text())
+  }
+
+  async status(backendId: string): Promise<BackendState> {
+    const url = `${this.apiUrl}/v2/backend/${backendId}/status`
+    const response = checkResponse('status()', await fetch(url, { cache: 'no-store' }))
+    return parseAs<BackendState>(isBackendState, await response.text())
+  }
+
+  async statusStream(backendId: string, onStatus: OnStatusCallback): Promise<UnsubscribeFn> {
+    const url = `${this.apiUrl}/v2/backend/${backendId}/status/stream`
+
+    // keep track of the statuses we've seen since we might have just resubscribed
+    // to the status stream and are seeing some of the statuses we've already seen again
+    const statusesSeen = new Set<BackendStatus>()
+    let unsubscribed = false
+    let retries = 0
+    let streamReader: ReadableStreamDefaultReader<string> | null = null
+    function unsubscribe() {
+      unsubscribed = true
+      streamReader?.cancel()
+      streamReader = null
+    }
+
+    async function startStatusStream() {
+      try {
+        const response = checkResponse('statusStream()', await fetch(url, { cache: 'no-store' }))
+        // make sure only one streamReader is running at a time
+        if (streamReader !== null) streamReader.cancel()
+        streamReader = response.body.pipeThrough(new TextDecoderStream()).getReader()
+        while (streamReader !== null && unsubscribed === false) {
+          const result = await streamReader.read()
+          if (unsubscribed || !result.value || result.done) break
+
+          result.value.split('\n').forEach((line) => {
+            line = line?.trim()
+            if (!line?.startsWith('data:')) return
+
+            // remove the 'data: ' prefix
+            const text = line.slice(5).trim()
+            try {
+              var backendState = parseAs<BackendState>(isBackendState, text)
+            } catch (e) {
+              console.error(e)
+              return
+            }
+
+            if (statusesSeen.has(backendState.status)) return
+            statusesSeen.add(backendState.status)
+            onStatus(backendState)
+          })
+
+          if (statusesSeen.has('terminated')) {
+            unsubscribe()
+          }
+        }
+
+        // if the stream has terminated but we haven't unsubscribed and the backend has not terminated,
+        // wait a little bit then resubscribe
+        if (!unsubscribed && !statusesSeen.has('terminated')) {
+          // the thrown error will be caught below and the stream will be restarted
+          throw new Error('Jamsocket status stream ended unexpectedly')
+        }
+      } catch (e) {
+        retries += 1
+        if (retries > 3) {
+          console.error(`Jamsocket: encountered error getting status stream. No more retries.`)
+          return
+        }
+        console.error(`Jamsocket: encountered error getting status stream. Retry ${retries}`)
+        setTimeout(startStatusStream, 2000)
       }
-      throw new Error(`Error spawning backend: ${response.status} ${bodyText}`)
     }
-    try {
-      return JSON.parse(bodyText) as ConnectResponse
-    } catch (e) {
-      throw new Error(`Error parsing connect response: ${bodyText}`)
-    }
+    startStatusStream()
+    return unsubscribe
   }
 }

--- a/packages/typescript/server/src/utils.ts
+++ b/packages/typescript/server/src/utils.ts
@@ -1,0 +1,46 @@
+import { HTTPError } from '@jamsocket/types'
+
+export function validatePort(port: any): number {
+  if (!Number.isInteger(port)) {
+    throw new Error(`Jamsocket dev port must be an integer, got ${typeof port}`)
+  }
+  return port
+}
+
+export type SuccessfulResponse = Response & {
+  ok: true
+  body: NonNullable<ReadableStream<Uint8Array>>
+}
+
+export function checkResponse(description: string, response: Response): SuccessfulResponse {
+  if (!response.ok) {
+    if (response.status === 429) {
+      console.warn(
+        "You've hit a rate limit with the Jamsocket API. If you are on the free tier, you may have hit our free tier limits. Learn more at https://docs.jamsocket.com/pricing/free-tier-limits",
+      )
+    }
+    throw new HTTPError(
+      response.status,
+      `Jamsocket: An error occured while calling ${description}: ${response.status} ${response.statusText}`,
+    )
+  }
+
+  if (!response.body) {
+    throw new Error(
+      `Jamsocket: An error occured while calling ${description}: response did not include body`,
+    )
+  }
+
+  return response as SuccessfulResponse
+}
+
+export function parseAs<T>(isFn: (msg: any) => msg is T, text: string): T {
+  let msg = null
+  try {
+    msg = JSON.parse(text)
+  } catch {}
+  if (!isFn(msg)) {
+    throw new Error(`Jamsocket: Error parsing message format: ${text}`)
+  }
+  return msg
+}

--- a/packages/typescript/session-backend/server/README.md
+++ b/packages/typescript/session-backend/server/README.md
@@ -1,0 +1,36 @@
+# @jamsocket/session-backend
+
+[![GitHub Repo stars](https://img.shields.io/github/stars/jamsocket/jamsocket?style=social)](https://github.com/jamsocket/jamsocket)
+[![Chat on Discord](https://img.shields.io/discord/939641163265232947)](https://discord.gg/N5sEpsuhh9)
+[![npm](https://img.shields.io/npm/v/@jamsocket/server)](https://www.npmjs.com/package/@jamsocket/session-backend)
+
+JavaScript/TypeScript library to be used inside a session backend.
+
+Read the [docs here](https://docs.jamsocket.com)
+
+## Installation
+```bash copy
+npm install @jamsocket/session-backend
+```
+
+## Example usage
+
+```ts
+import { JamsocketBackend } from '@jamsocket/session-backend'
+
+const jamsocketBackend = new JamsocketBackend() // auto-configures itself from environment variables
+
+// listenForRequests is assumed to start your application server on the given port. We can either do this
+// before or after awaiting the key assignment, but we MUST be ready for requests on jamsocketBackend.port before
+// we call assignment.ready().
+listenForRequests(jamsocketBackend.port)
+
+const assignment = await jamsocketBackend.assignment()
+
+console.log('key', assignment.key)
+console.log('backendId', assignment.backendId)
+
+// Optionally, do some initialization work here based on the key or other fields of assignment.
+
+assignment.ready()
+```

--- a/packages/typescript/session-backend/server/package.json
+++ b/packages/typescript/session-backend/server/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@jamsocket/session-backend",
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "dev": "tsup --watch",
+    "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
+  },
+  "version": "0.0.5",
+  "description": "A preview of the upcoming Jamsocket Session Backend SDK.",
+  "main": "./dist/main.js",
+  "types": "./dist/main.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/main.d.mts",
+        "default": "./dist/main.mjs"
+      },
+      "require": {
+        "types": "./dist/main.d.ts",
+        "module": "./dist/main.mjs",
+        "default": "./dist/main.js"
+      }
+    }
+  },
+  "files": [
+    "dist/**/*"
+  ],
+  "author": "Taylor Baldwin <taylor@driftingin.space>",
+  "homepage": "https://github.com/jamsocket/jamsocket",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jamsocket/jamsocket.git",
+    "directory": "packages/typescript/session-backend"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jamsocket/jamsocket/issues"
+  }
+}

--- a/packages/typescript/session-backend/server/src/main.ts
+++ b/packages/typescript/session-backend/server/src/main.ts
@@ -1,0 +1,128 @@
+import * as net from 'net'
+import * as fs from 'fs'
+import * as readline from 'readline'
+
+const JAMSOCKET_SDK_SOCKET = '/jamsocket-control/jamsocket-sdk.sock'
+
+/** Represents an assignment of the backend to a specific key.
+ * This happens exactly once in a backend's lifecycle.
+ */
+export class BackendAssignment {
+  /** The ID of the backend. */
+  backendId: string
+
+  /** The key that the backend is assigned to. */
+  key: string
+
+  /** A "fencing token" that the backend can use as a fencing token. (You probably don't need this; see
+   * https://docs.jamsocket.com/platform/reference#backend-containers for more info.) */
+  fencingToken?: number | null
+
+  staticToken?: string | null
+
+  env: Record<string, string | undefined>
+
+  isReady: boolean = false
+
+  constructor(assignmentMsg: BackendAssignmentSocketMsg['message']['BackendAssignment'], private client: net.Socket | null) {
+    this.backendId = assignmentMsg.backend_id
+    this.key = assignmentMsg.key
+    this.fencingToken = assignmentMsg.fencing_token
+    this.staticToken = assignmentMsg.static_token
+    this.env = assignmentMsg.env
+  }
+
+  /** Method to call once this backend is ready to receive requests.
+   * This allows the backend to do some initialization work between receiving the key assignment
+   * and being sent requests from proxies.
+   */
+  ready() {
+    // if there is no client, then we are not running with warm pools, so we don't need to do anything
+    if (this.client) {
+      // send a request over unix socket that the backend is ready to receive HTTP requests
+      this.client.write(JSON.stringify({ message: 'Ready' }) + '\n')
+    }
+    this.isReady = true
+  }
+}
+
+export type BackendAssignmentSocketMsg = {
+  message: {
+    BackendAssignment: {
+      backend_id: string
+      key: string
+      fencing_token?: number | null
+      static_token?: string | null
+      env: Record<string, string | undefined>
+    }
+  }
+}
+
+export function isBackendAssignmentSocketMsg(msg: any): msg is BackendAssignmentSocketMsg {
+  return msg.message && msg.message.BackendAssignment
+}
+
+export class JamsocketBackend {
+  /** Environment variables passed when the backend started. */
+  public env = process.env as Record<string, string>
+
+  /** The port that the backend is expected to listen on. */
+  public port = parseInt(process.env.PORT || '8080', 10)
+
+  private client: net.Socket | null = null
+
+  public supportsWarmPools: boolean
+
+  constructor() {
+    this.supportsWarmPools = fs.existsSync(JAMSOCKET_SDK_SOCKET)
+    if (!this.supportsWarmPools) {
+      console.warn(`No socket found at "${JAMSOCKET_SDK_SOCKET}". Assuming not running with Warm Pool support.`)
+    }
+  }
+
+  async assignment(): Promise<BackendAssignment> {
+    if (!this.supportsWarmPools) {
+      // filter out SESSION_BACKEND_ID, SESSION_BACKEND_KEY, SESSION_BACKEND_FENCING_TOKEN, and SESSION_BACKEND_STATIC_TOKEN
+      const { SESSION_BACKEND_ID, SESSION_BACKEND_KEY, SESSION_BACKEND_FENCING_TOKEN, SESSION_BACKEND_STATIC_TOKEN, ...env } = process.env
+      return new BackendAssignment({
+        backend_id: SESSION_BACKEND_ID!,
+        key: SESSION_BACKEND_KEY!,
+        fencing_token: SESSION_BACKEND_FENCING_TOKEN ? parseInt(SESSION_BACKEND_FENCING_TOKEN, 10) : null,
+        static_token: SESSION_BACKEND_STATIC_TOKEN || null,
+        env,
+      }, null)
+    }
+
+    this.client = await new Promise<net.Socket>((resolve) => {
+      const c: net.Socket = net.createConnection(JAMSOCKET_SDK_SOCKET, () => resolve(c))
+    })
+
+    const rl = readline.createInterface({ input: this.client })
+
+    const assignmentMsgPromise = new Promise<
+      BackendAssignmentSocketMsg['message']['BackendAssignment']
+    >((resolve, reject) => {
+      rl.on('line', (line) => {
+        const message = JSON.parse(line)
+        if (!isBackendAssignmentSocketMsg(message)) {
+          console.error('Received unexpected message:', message)
+          return
+        }
+        resolve(message.message.BackendAssignment)
+      })
+    })
+
+    this.client.on('error', (err) => {
+      console.error('Error listening on Socket:', err.message)
+    })
+
+    // send a request over unix socket that the backend is warmed up
+    this.client.write(JSON.stringify({ message: 'Warmed' }) + '\n')
+
+    // wait for a request over the unix socket to "start" the backend
+    const assignmentMsg = await assignmentMsgPromise
+    const mergedEnv = { ...process.env, ...assignmentMsg.env }
+    assignmentMsg.env = mergedEnv
+    return new BackendAssignment(assignmentMsg, this.client)
+  }
+}

--- a/packages/typescript/session-backend/server/tsconfig.json
+++ b/packages/typescript/session-backend/server/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src/**/*"]
+}

--- a/packages/typescript/session-backend/server/tsup.config.ts
+++ b/packages/typescript/session-backend/server/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/main.ts'],
+  dts: true,
+  splitting: true,
+  clean: true,
+  target: 'es2020',
+  format: ['esm', 'cjs'],
+  sourcemap: true,
+})

--- a/packages/typescript/socketio/package.json
+++ b/packages/typescript/socketio/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "React hooks for interacting with socket.io servers in Jamsocket session backends.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/react": "1.0.0",
+    "@jamsocket/react": "1.1.0",
     "socket.io-client": "^4.7.4"
   },
   "peerDependencies": {

--- a/packages/typescript/types/package.json
+++ b/packages/typescript/types/package.json
@@ -13,10 +13,13 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/main.d.mts"
+        "types": "./dist/main.d.mts",
+        "default": "./dist/main.mjs"
       },
       "require": {
-        "types": "./dist/main.d.ts"
+        "types": "./dist/main.d.ts",
+        "module": "./dist/main.mjs",
+        "default": "./dist/main.js"
       }
     }
   },

--- a/packages/typescript/types/package.json
+++ b/packages/typescript/types/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "JavaScript/TypeScript libraries for spawning session backends server-side.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/packages/typescript/types/src/main.ts
+++ b/packages/typescript/types/src/main.ts
@@ -69,3 +69,40 @@ export type ConnectRequest = {
   user?: string
   auth?: Record<string, any>
 }
+
+export function isConnectResponse(msg: any): msg is ConnectResponse {
+  if (typeof msg !== 'object') return false
+  if (typeof msg.backend_id !== 'string') return false
+  if (typeof msg.spawned !== 'boolean') return false
+  if (typeof msg.status !== 'string') return false
+  if (typeof msg.token !== 'string') return false
+  if (typeof msg.url !== 'string') return false
+  if (typeof msg.status_url !== 'string') return false
+  return true
+}
+
+export function isBackendState(msg: any): msg is BackendState {
+  if (typeof msg !== 'object') return false
+  if (typeof msg.status !== 'string') return false
+  if (typeof msg.time !== 'string') return false
+  if (
+    msg.status === 'terminating' ||
+    msg.status === 'hard-terminating' ||
+    msg.termination_reason !== undefined
+  ) {
+    if (typeof msg.termination_reason !== 'string') return false
+  }
+  if (msg.termination_kind !== undefined && typeof msg.termination_kind !== 'string') return false
+  if (msg.exit_error !== undefined && typeof msg.exit_error !== 'boolean') return false
+  return true
+}
+
+export class HTTPError extends Error {
+  constructor(
+    public code: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'HTTPError'
+  }
+}

--- a/packages/typescript/types/tsup.config.ts
+++ b/packages/typescript/types/tsup.config.ts
@@ -5,4 +5,7 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
+  target: 'es2020',
+  format: ['esm', 'cjs'],
+  sourcemap: true,
 })


### PR DESCRIPTION
This `status()` and `statusStream()` functions to `@jamsocket/server`. It also adds an alpha version of the session backend SDK. Finally, it removes its dependency on the `isomorphic-fetch` polyfill since we've long required Node >=18 which has `fetch`. Also Node 16's end of life was about a year ago.