### PR TITLE
Lots of misc changes - see description

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -136,8 +136,8 @@ Gets a URL that can be used to connect to a session backend. Will spawn a new se
 
 ```
 USAGE
-  $ jamsocket connect [SERVICE] [-e <value>] [-t <value>] [-i <value>] [-l <value>] [-k <value>] [-u <value>]
-    [-a <value>] [--spawn]
+  $ jamsocket connect [SERVICE] [-e <value>] [-t <value>] [-c <value>] [-i <value>] [-l <value>] [-k <value>]
+    [-u <value>] [-a <value>] [--spawn]
 
 ARGUMENTS
   SERVICE  Name of service to spawn.
@@ -145,6 +145,8 @@ ARGUMENTS
 FLAGS
   -a, --auth=<value>                    Optional serialized JSON to be passed to a session backend when connecting with
                                         the returned URL/connection string.
+  -c, --cluster=<value>                 The cluster to to spawn the backend in (only relevant if you are running
+                                        multiple clusters with Jamsocket).
   -e, --env=<value>...                  optional environment variables to pass to the container
   -i, --max-idle-seconds=<value>        The max time in seconds a session backend should wait after last connection is
                                         closed before shutting down container (default is 300)
@@ -310,18 +312,20 @@ Builds and pushes an image to Jamsocket's container registry using the provided 
 
 ```
 USAGE
-  $ jamsocket push [SERVICE] [IMAGE] [-f <value>] [-c <value>] [-t <value>] [-g]
+  $ jamsocket push [SERVICE] [IMAGE] [-f <value>] [-c <value>] [-b <value>] [-t <value>] [-g]
 
 ARGUMENTS
   SERVICE  Jamsocket service to push the image to
   IMAGE    Optionally, provide an image to push instead of a Dockerfile
 
 FLAGS
-  -c, --context=<value>     path to the build context for the Dockerfile (defaults to current working directory)
-  -f, --dockerfile=<value>  path to the Dockerfile to build the image from
-  -g, --include-git-commit  optionally include git commit metadata as labels in the image (uses the git repo of the
-                            docker context)
-  -t, --tag=<value>         optional tag to apply to the image in the jamsocket registry
+  -b, --build-context=<value>...  Additional named build contexts to be used when building the image (e.g.
+                                  --build-context alpine=docker-image://alpine@sha256:0123456789)
+  -c, --context=<value>           path to the build context for the Dockerfile (defaults to current working directory)
+  -f, --dockerfile=<value>        path to the Dockerfile to build the image from
+  -g, --include-git-commit        optionally include git commit metadata as labels in the image (uses the git repo of
+                                  the docker context)
+  -t, --tag=<value>               optional tag to apply to the image in the jamsocket registry
 
 DESCRIPTION
   Builds and pushes an image to Jamsocket's container registry using the provided Dockerfile.
@@ -340,8 +344,8 @@ Gets a URL that can be used to connect to a session backend. Will spawn a new se
 
 ```
 USAGE
-  $ jamsocket service connect [SERVICE] [-e <value>] [-t <value>] [-i <value>] [-l <value>] [-k <value>] [-u <value>]
-    [-a <value>] [--spawn]
+  $ jamsocket service connect [SERVICE] [-e <value>] [-t <value>] [-c <value>] [-i <value>] [-l <value>] [-k <value>]
+    [-u <value>] [-a <value>] [--spawn]
 
 ARGUMENTS
   SERVICE  Name of service to spawn.
@@ -349,6 +353,8 @@ ARGUMENTS
 FLAGS
   -a, --auth=<value>                    Optional serialized JSON to be passed to a session backend when connecting with
                                         the returned URL/connection string.
+  -c, --cluster=<value>                 The cluster to to spawn the backend in (only relevant if you are running
+                                        multiple clusters with Jamsocket).
   -e, --env=<value>...                  optional environment variables to pass to the container
   -i, --max-idle-seconds=<value>        The max time in seconds a session backend should wait after last connection is
                                         closed before shutting down container (default is 300)

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jamsocket",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jamsocket",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "1.9.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamsocket",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "A CLI for the Jamsocket platform",
   "author": "Taylor Baldwin <taylor@driftingin.space>",
   "bin": {

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -46,8 +46,9 @@ export type V2Status =
   | 'terminated'
 
 export type ConnectResourceLimits = {
+  // The CPU period (in microseconds), defaults to 100_000 (100ms)
   cpu_period?: number
-  // Proportion of period used by container (in microseconds)
+  // Proportion of period the container is allowed to use (in percent, e.g. 100 = 100%)
   cpu_period_percent?: number
   // Total cpu time allocated to container (in seconds)
   cpu_time_limit?: number
@@ -61,6 +62,7 @@ export type JamsocketConnectRequestBody = {
     | boolean
     | {
         tag?: string
+        cluster?: string
         lifetime_limit_seconds?: number
         max_idle_seconds?: number
         executable?: {

--- a/cli/src/commands/push.ts
+++ b/cli/src/commands/push.ts
@@ -27,6 +27,12 @@ export default class Push extends Command {
       description:
         'path to the build context for the Dockerfile (defaults to current working directory)',
     }),
+    ['build-context']: Flags.string({
+      char: 'b',
+      multiple: true,
+      description:
+        'Additional named build contexts to be used when building the image (e.g. --build-context alpine=docker-image://alpine@sha256:0123456789)',
+    }),
     tag: Flags.string({
       char: 't',
       description: 'optional tag to apply to the image in the jamsocket registry',
@@ -63,6 +69,9 @@ export default class Push extends Command {
     if (args.image) {
       if (flags.context !== undefined) {
         throw new Error('--context flag should only be used with the --dockerfile flag')
+      }
+      if (flags['build-context']) {
+        throw new Error('--build-context flag should only be used with the --dockerfile flag')
       }
       if (flags['include-git-commit']) {
         throw new Error(
@@ -148,6 +157,9 @@ export default class Push extends Command {
       const options: BuildImageOptions = { labels }
       if (flags.context) {
         options.path = resolve(process.cwd(), flags.context)
+      }
+      if (flags['build-context']) {
+        options.buildContexts = flags['build-context']
       }
       this.log(blue(`Building image from Dockerfile: ${flags.dockerfile}`))
       image = await buildImage(flags.dockerfile, options)

--- a/cli/src/commands/service/connect.ts
+++ b/cli/src/commands/service/connect.ts
@@ -29,6 +29,11 @@ export default class Spawn extends Command {
       char: 't',
       description: 'An optional image tag or image digest to use when spawning a backend.',
     }),
+    cluster: Flags.string({
+      char: 'c',
+      description:
+        'The cluster to to spawn the backend in (only relevant if you are running multiple clusters with Jamsocket).',
+    }),
     'max-idle-seconds': Flags.integer({
       char: 'i',
       description:
@@ -98,6 +103,9 @@ export default class Spawn extends Command {
       if (flags.tag) {
         this.warn('Ignoring --tag flag because --no-spawn flag was provided.')
       }
+      if (flags.cluster) {
+        this.warn('Ignoring --cluster flag because --no-spawn flag was provided.')
+      }
       if (flags['max-idle-seconds']) {
         this.warn('Ignoring --max-idle-seconds flag because --no-spawn flag was provided.')
       }
@@ -111,6 +119,7 @@ export default class Spawn extends Command {
     } else {
       connectReqBody.spawn = {
         tag: flags.tag,
+        cluster: flags.cluster,
         executable: {
           env,
         },

--- a/cli/src/dev-server/index.ts
+++ b/cli/src/dev-server/index.ts
@@ -344,8 +344,13 @@ class DevServer {
       }
 
       backend.lastStatus = status
+      let statusText = status.status
+      if (status.status === 'terminated') {
+        if (status.termination_reason) statusText += ` (${status.termination_reason})`
+        if (status.exit_error) statusText += ` (exited with error)`
+      }
       this.logger.log([
-        `Status for ${this.applyBackendStyle(backend, backend.name)}: ${status.status}`,
+        `Status for ${this.applyBackendStyle(backend, backend.name)}: ${statusText}`,
       ])
       if (!isV2StatusAlive(status.status)) {
         backend.statusStream?.close()

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -27,6 +27,7 @@ export function getImagePlatform(imageName: string): { os: string; arch: string 
 export type BuildImageOptions = {
   path?: string
   labels?: Record<string, string>
+  buildContexts?: string[]
 }
 
 type StdioWriteFn = (val: string) => void
@@ -41,6 +42,7 @@ export async function buildImage(
   const optionsWithDefaults: Required<BuildImageOptions> = {
     path: '.',
     labels: {},
+    buildContexts: [],
     ...options,
   }
 
@@ -49,6 +51,10 @@ export async function buildImage(
   for (const [key, value] of labels) {
     args.push('--label')
     args.push(`${key}=${value}`)
+  }
+  for (const buildContext of optionsWithDefaults.buildContexts) {
+    args.push('--build-context')
+    args.push(buildContext)
   }
   args.push(optionsWithDefaults.path)
 

--- a/examples/multiplayer-editor/package.json
+++ b/examples/multiplayer-editor/package.json
@@ -9,14 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@jamsocket/server": "1.1.0",
-    "@jamsocket/socketio": "1.1.0",
+    "@jamsocket/server": "1.1.1",
+    "@jamsocket/socketio": "1.1.1",
     "next": "13.4.9",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "server-only": "^0.0.1",
     "socket.io": "^4.6.1"
-
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^26.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
     "examples/multiplayer-editor": {
       "version": "0.1.0",
       "dependencies": {
-        "@jamsocket/server": "1.1.0",
-        "@jamsocket/socketio": "1.1.0",
+        "@jamsocket/server": "1.1.1",
+        "@jamsocket/socketio": "1.1.1",
         "next": "13.4.9",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -6654,18 +6654,18 @@
     },
     "packages/typescript/client": {
       "name": "@jamsocket/client",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/types": "1.1.0"
+        "@jamsocket/types": "1.1.1"
       }
     },
     "packages/typescript/react": {
       "name": "@jamsocket/react",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/client": "1.1.0"
+        "@jamsocket/client": "1.1.1"
       },
       "devDependencies": {
         "@types/react": "^18.2.59"
@@ -6676,18 +6676,18 @@
     },
     "packages/typescript/server": {
       "name": "@jamsocket/server",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/types": "1.1.0"
+        "@jamsocket/types": "1.1.1"
       }
     },
     "packages/typescript/socketio": {
       "name": "@jamsocket/socketio",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
-        "@jamsocket/react": "1.1.0",
+        "@jamsocket/react": "1.1.1",
         "socket.io-client": "^4.7.4"
       },
       "devDependencies": {
@@ -6699,7 +6699,7 @@
     },
     "packages/typescript/types": {
       "name": "@jamsocket/types",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT"
     }
   }

--- a/packages/typescript/client/package.json
+++ b/packages/typescript/client/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "JavaScript/TypeScript libraries for interacting with session backends and the Jamsocket platform.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,6 +38,6 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/types": "1.1.0"
+    "@jamsocket/types": "1.1.1"
   }
 }

--- a/packages/typescript/react/package.json
+++ b/packages/typescript/react/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React hooks for interacting with session backends and the Jamsocket platform.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/client": "1.1.0"
+    "@jamsocket/client": "1.1.1"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0"

--- a/packages/typescript/server/README.md
+++ b/packages/typescript/server/README.md
@@ -202,6 +202,7 @@ type ConnectRequest = {
     | boolean
     | {
         tag?: string
+        cluster?: string
         lifetime_limit_seconds?: number
         max_idle_seconds?: number
         executable?: {

--- a/packages/typescript/server/README.md
+++ b/packages/typescript/server/README.md
@@ -209,8 +209,9 @@ type ConnectRequest = {
           mount?: string | boolean
           env?: Record<string, string>
           resource_limits?: {
+            // The CPU period (in microseconds), defaults to 100_000 (100ms)
             cpu_period?: number
-            // Proportion of period used by container (in microseconds)
+            // Proportion of period the container is allowed to use (in percent, e.g. 100 = 100%)
             cpu_period_percent?: number
             // Total cpu time allocated to container (in seconds)
             cpu_time_limit?: number

--- a/packages/typescript/server/README.md
+++ b/packages/typescript/server/README.md
@@ -88,6 +88,17 @@ const jamsocket = new Jamsocket({
 })
 ```
 
+### `fromEnv(env)`
+
+The `Jamsocket` class comes with a static method that returns an instance of `Jamsocket` configured by the provided environment. The `fromEnv()` method expects to find either `JAMSOCKET_TOKEN`, `JAMSOCKET_ACCOUNT`, and `JAMSOCKET_SERVICE` values _or_ a `JAMSOCKET_DEV: true` value. If running in dev mode, the function will also accept an optional `JAMSOCKET_DEV_PORT` which tells the `Jamsocket` instance where to find the dev server. (This is only needed if you're running `npx jamsocket dev` with a custom port.)
+
+Example:
+
+```ts
+import { Jamsocket } from '@jamsocket/server'
+const jamsocket = Jamsocket.fromEnv(process.env)
+```
+
 ### `connect()`
 
 The Jamsocket instance includes a `connect` function that you can use to get a connection URL for a session backend. If you provide a `key`, the connect function will either spawn a new backend or return the running backend that holds the provided key if one exists. When generating a connection URL for a backend, you can provide an optional `ConnectRequest` object. It returns a promise, which resolves with a `ConnectResponse`.

--- a/packages/typescript/server/package.json
+++ b/packages/typescript/server/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "JavaScript/TypeScript libraries for spawning session backends server-side.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,6 +38,6 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/types": "1.1.0"
+    "@jamsocket/types": "1.1.1"
   }
 }

--- a/packages/typescript/server/src/main.ts
+++ b/packages/typescript/server/src/main.ts
@@ -41,6 +41,27 @@ export class Jamsocket {
   token: string
   apiUrl: string
 
+  static fromEnv(env: Record<string, string | undefined>): Jamsocket {
+    if (env.JAMSOCKET_DEV === 'true') {
+      let port = JAMSOCKET_DEV_PORT
+      if (typeof env.JAMSOCKET_DEV_PORT === 'string') {
+        port = validatePort(parseInt(env.JAMSOCKET_DEV_PORT, 10))
+      }
+      return new Jamsocket({ dev: true, port })
+    }
+    if (!env.JAMSOCKET_ACCOUNT || !env.JAMSOCKET_TOKEN || !env.JAMSOCKET_SERVICE) {
+      throw new Error(
+        'Jamsocket.fromEnv(): JAMSOCKET_ACCOUNT, JAMSOCKET_TOKEN, and JAMSOCKET_SERVICE must be provided in the environment',
+      )
+    }
+    return new Jamsocket({
+      account: env.JAMSOCKET_ACCOUNT,
+      token: env.JAMSOCKET_TOKEN,
+      service: env.JAMSOCKET_SERVICE,
+      apiUrl: env.JAMSOCKET_API_URL,
+    })
+  }
+
   constructor(opts: JamsocketInitOptions) {
     if (isJamsocketDevInitOptions(opts)) {
       this.account = '-'

--- a/packages/typescript/socketio/package.json
+++ b/packages/typescript/socketio/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React hooks for interacting with socket.io servers in Jamsocket session backends.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
@@ -38,7 +38,7 @@
     "url": "https://github.com/jamsocket/jamsocket/issues"
   },
   "dependencies": {
-    "@jamsocket/react": "1.1.0",
+    "@jamsocket/react": "1.1.1",
     "socket.io-client": "^4.7.4"
   },
   "peerDependencies": {

--- a/packages/typescript/types/README.md
+++ b/packages/typescript/types/README.md
@@ -84,6 +84,7 @@ type ConnectRequest = {
     | boolean
     | {
         tag?: string
+        cluster?: string
         lifetime_limit_seconds?: number
         max_idle_seconds?: number
         executable?: {

--- a/packages/typescript/types/README.md
+++ b/packages/typescript/types/README.md
@@ -91,8 +91,9 @@ type ConnectRequest = {
           mount?: string | boolean
           env?: Record<string, string>
           resource_limits?: {
+            // The CPU period (in microseconds), defaults to 100_000 (100ms)
             cpu_period?: number
-            // Proportion of period used by container (in microseconds)
+            // Proportion of period the container is allowed to use (in percent, e.g. 100 = 100%)
             cpu_period_percent?: number
             // Total cpu time allocated to container (in seconds)
             cpu_time_limit?: number

--- a/packages/typescript/types/package.json
+++ b/packages/typescript/types/package.json
@@ -6,7 +6,7 @@
     "dev": "tsup --watch",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "JavaScript/TypeScript libraries for spawning session backends server-side.",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/packages/typescript/types/src/main.ts
+++ b/packages/typescript/types/src/main.ts
@@ -50,6 +50,7 @@ export type ConnectRequest = {
     | boolean
     | {
         tag?: string
+        cluster?: string
         lifetime_limit_seconds?: number
         max_idle_seconds?: number
         executable?: {

--- a/packages/typescript/types/src/main.ts
+++ b/packages/typescript/types/src/main.ts
@@ -57,8 +57,9 @@ export type ConnectRequest = {
           mount?: string | boolean
           env?: Record<string, string>
           resource_limits?: {
+            // The CPU period (in microseconds), defaults to 100_000 (100ms)
             cpu_period?: number
-            // Proportion of period used by container (in microseconds)
+            // Proportion of period the container is allowed to use (in percent, e.g. 100 = 100%)
             cpu_period_percent?: number
             // Total cpu time allocated to container (in seconds)
             cpu_time_limit?: number


### PR DESCRIPTION
- [x] adds a `fromEnv` static method to `Jamsocket` class in `@jamsocket/server`
- [x] adds `cluster` to the `ConnectRequest` type for TypeScript libraries
- [x] adds `cluster` support to the connect command in the CLI
- [x] fixes comments about ResourceLimits
- [x] adds more metadata about terminated statuses to dev CLI output
- [x] adds additional named docker contexts option to CLI push command (closes #132)
- [x] updates READMEs for CLI, `@jamsocket/server` and `@jamsocket/types`