### PR TITLE
add _isDestroyed flag that prevents resubscribing to status stream

### DIFF
--- a/packages/typescript/client/src/main.ts
+++ b/packages/typescript/client/src/main.ts
@@ -26,6 +26,8 @@ export class SessionBackend {
   public onTerminatedPromise: Promise<void>
   private _onTerminatedResolve!: () => void
 
+  private _isDestroyed: boolean = false
+
   private _onStatus: ((msg: BackendState) => void)[] = []
 
   constructor(connectResponse: ConnectResponse) {
@@ -120,7 +122,7 @@ export class SessionBackend {
       if (this.isTerminated()) this.destroyStatusStream()
     }
 
-    if (!this.isTerminated()) {
+    if (!this.isTerminated() && !this._isDestroyed) {
       console.error('Jamsocket status stream ended unexpectedly')
       this.destroyStatusStream() // make sure we don't have a dangling stream
       this.subscribeToStatusStream()
@@ -161,6 +163,7 @@ export class SessionBackend {
   }
 
   public destroy() {
+    this._isDestroyed = true
     this.destroyStatusStream()
   }
 


### PR DESCRIPTION
Currently in the client SDK, destroying a status stream with `destroy()` triggers the clause for detecting unexpected stream terminations and recreates the status stream. This causes an error some time later when the hanging stream times out.

![image](https://github.com/user-attachments/assets/16ec174f-5d2e-425d-bd07-ea48f67c1c44)

This change simply adds a flag, `_isDestroyed` to prevent the stream recreation in the case we actually did intend to close it!